### PR TITLE
Switch to tagless client variant

### DIFF
--- a/blockfrost-client/CHANGELOG.md
+++ b/blockfrost-client/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version [0.3.0.0](https://github.com/blockfrost/blockfrost-haskell/compare/v0.2.1.0...v0.3.0.0) (2022-02-07)
+
+* Changes
+  * Client functions switched to tagless variants using `MonadBlockfrost` allowing to use custom base monad
+    for client functions.  Provided instances for `BlockfrostClient`, `IO` and `ClientM`.
+
 # Version [0.2.1.0](https://github.com/blockfrost/blockfrost-haskell/compare/v0.2.0.0...v0.2.1.0) (2021-11-15)
 
 * Additions

--- a/blockfrost-client/src/Blockfrost/Client.hs
+++ b/blockfrost-client/src/Blockfrost/Client.hs
@@ -1,7 +1,5 @@
 -- | Blockfrost client
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DeriveFunctor #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Blockfrost.Client
   ( module Blockfrost.API
@@ -180,37 +178,37 @@ import Data.Text (Text)
 -- ** Client functions
 -- *** Health
 
-getRoot' :: Project -> BlockfrostClient URLVersion
+getRoot' :: MonadBlockfrost m => Project -> m URLVersion
 getRoot' = _getRoot . commonClient
 
 -- | Root endpoint has no other function than to point end users to documentation
-getRoot  :: BlockfrostClient URLVersion
+getRoot  :: MonadBlockfrost m => m URLVersion
 getRoot = go getRoot'
 
-getHealth' :: Project -> BlockfrostClient Healthy
+getHealth' :: MonadBlockfrost m => Project -> m Healthy
 getHealth' = _getHealth . commonClient
 
 -- | Return backend status. Your application should handle situations when backend for the given chain is unavailable.
-getHealth  :: BlockfrostClient Healthy
+getHealth  :: MonadBlockfrost m => m Healthy
 getHealth = go getHealth'
 
-getClock':: Project -> BlockfrostClient ServerTime
+getClock':: MonadBlockfrost m => Project -> m ServerTime
 getClock' = _getClock . commonClient
 
 -- | Get current backend time
-getClock:: BlockfrostClient ServerTime
+getClock :: MonadBlockfrost m => m ServerTime
 getClock = go getClock'
 
-getMetrics':: Project -> BlockfrostClient [Metric]
+getMetrics' :: MonadBlockfrost m => Project -> m [Metric]
 getMetrics' = _metrics . commonClient
 
 -- | Get Blockfrost usage metrics over last 30 days
-getMetrics:: BlockfrostClient [Metric]
+getMetrics :: MonadBlockfrost m => m [Metric]
 getMetrics = go getMetrics'
 
-getMetricsEndpoints':: Project -> BlockfrostClient [(Text, Metric)]
+getMetricsEndpoints' :: MonadBlockfrost m => Project -> m [(Text, Metric)]
 getMetricsEndpoints' = _metricsEndpoints . commonClient
 
 -- | Get Blockfrost endpoint usage metrics over last 30 days
-getMetricsEndpoints:: BlockfrostClient [(Text, Metric)]
+getMetricsEndpoints :: MonadBlockfrost m => m [(Text, Metric)]
 getMetricsEndpoints = go getMetricsEndpoints'

--- a/blockfrost-client/src/Blockfrost/Client/Cardano/Accounts.hs
+++ b/blockfrost-client/src/Blockfrost/Client/Cardano/Accounts.hs
@@ -24,108 +24,108 @@ import Blockfrost.API
 import Blockfrost.Client.Types
 import Blockfrost.Types
 
-accountsClient :: Project -> AccountsAPI (AsClientT BlockfrostClient)
+accountsClient :: MonadBlockfrost m => Project -> AccountsAPI (AsClientT m)
 accountsClient = fromServant . _accounts . cardanoClient
 
-getAccount_ :: Project -> Address -> BlockfrostClient AccountInfo
+getAccount_ :: MonadBlockfrost m => Project -> Address -> m AccountInfo
 getAccount_ = _account . accountsClient
 
 -- | Obtain information about a specific stake account.
-getAccount :: Address -> BlockfrostClient AccountInfo
+getAccount :: MonadBlockfrost m => Address -> m AccountInfo
 getAccount a = go (`getAccount_` a)
 
-getAccountRewards_ :: Project -> Address -> Paged -> SortOrder -> BlockfrostClient [AccountReward]
+getAccountRewards_ :: MonadBlockfrost m => Project -> Address -> Paged -> SortOrder -> m [AccountReward]
 getAccountRewards_ = _accountRewards . accountsClient
 
 -- | Obtain information about the history of a specific account.
 -- Allows custom paging and ordering using @Paged@ and @SortOrder@.
-getAccountRewards' :: Address -> Paged -> SortOrder -> BlockfrostClient [AccountReward]
+getAccountRewards' :: MonadBlockfrost m => Address -> Paged -> SortOrder -> m [AccountReward]
 getAccountRewards' a pg s = go (\p -> getAccountRewards_ p a pg s)
 
 -- | Obtain information about the history of a specific account.
-getAccountRewards :: Address -> BlockfrostClient [AccountReward]
+getAccountRewards :: MonadBlockfrost m => Address -> m [AccountReward]
 getAccountRewards a = getAccountRewards' a def def
 
-getAccountHistory_ :: Project -> Address -> Paged -> SortOrder -> BlockfrostClient [AccountHistory]
+getAccountHistory_ :: MonadBlockfrost m => Project -> Address -> Paged -> SortOrder -> m [AccountHistory]
 getAccountHistory_ = _accountHistory . accountsClient
 
 -- | Obtain information about the history of a specific account.
 -- Allows custom paging and ordering using @Paged@ and @SortOrder@.
-getAccountHistory' :: Address -> Paged -> SortOrder -> BlockfrostClient [AccountHistory]
+getAccountHistory' :: MonadBlockfrost m => Address -> Paged -> SortOrder -> m [AccountHistory]
 getAccountHistory' a pg s = go (\p -> getAccountHistory_ p a pg s)
 
 -- | Obtain information about the history of a specific account.
-getAccountHistory :: Address -> BlockfrostClient [AccountHistory]
+getAccountHistory :: MonadBlockfrost m => Address -> m [AccountHistory]
 getAccountHistory a = getAccountHistory' a def def
 
-getAccountDelegations_ :: Project -> Address -> Paged -> SortOrder -> BlockfrostClient [AccountDelegation]
+getAccountDelegations_ :: MonadBlockfrost m => Project -> Address -> Paged -> SortOrder -> m [AccountDelegation]
 getAccountDelegations_ = _accountDelegations . accountsClient
 
 -- | Obtain information about the delegation of a specific account.
 -- Allows custom paging and ordering using @Paged@ and @SortOrder@.
-getAccountDelegations' :: Address -> Paged -> SortOrder -> BlockfrostClient [AccountDelegation]
+getAccountDelegations' :: MonadBlockfrost m => Address -> Paged -> SortOrder -> m [AccountDelegation]
 getAccountDelegations' a pg s = go (\p -> getAccountDelegations_ p a pg s)
 
 -- | Obtain information about the delegation of a specific account.
-getAccountDelegations :: Address -> BlockfrostClient [AccountDelegation]
+getAccountDelegations :: MonadBlockfrost m => Address -> m [AccountDelegation]
 getAccountDelegations a = getAccountDelegations' a def def
 
-getAccountRegistrations_ :: Project -> Address -> Paged -> SortOrder -> BlockfrostClient [AccountRegistration]
+getAccountRegistrations_ :: MonadBlockfrost m => Project -> Address -> Paged -> SortOrder -> m [AccountRegistration]
 getAccountRegistrations_ = _accountRegistrations . accountsClient
 
 -- | Obtain information about the registrations and deregistrations of a specific account.
 -- Allows custom paging and ordering using @Paged@ and @SortOrder@.
-getAccountRegistrations' :: Address -> Paged -> SortOrder -> BlockfrostClient [AccountRegistration]
+getAccountRegistrations' :: MonadBlockfrost m => Address -> Paged -> SortOrder -> m [AccountRegistration]
 getAccountRegistrations' a pg s = go (\p -> getAccountRegistrations_ p a pg s)
 
 -- | Obtain information about the registrations and deregistrations of a specific account.
-getAccountRegistrations :: Address -> BlockfrostClient [AccountRegistration]
+getAccountRegistrations :: MonadBlockfrost m => Address -> m [AccountRegistration]
 getAccountRegistrations a = getAccountRegistrations' a def def
 
-getAccountWithdrawals_ :: Project -> Address -> Paged -> SortOrder ->  BlockfrostClient [AccountWithdrawal]
+getAccountWithdrawals_ :: MonadBlockfrost m => Project -> Address -> Paged -> SortOrder ->  m [AccountWithdrawal]
 getAccountWithdrawals_ = _accountWithdrawals . accountsClient
 
 -- | Obtain information about the withdrawals of a specific account.
 -- Allows custom paging and ordering using @Paged@ and @SortOrder@.
-getAccountWithdrawals' :: Address -> Paged -> SortOrder -> BlockfrostClient [AccountWithdrawal]
+getAccountWithdrawals' :: MonadBlockfrost m => Address -> Paged -> SortOrder -> m [AccountWithdrawal]
 getAccountWithdrawals' a pg s = go (\p -> getAccountWithdrawals_ p a pg s)
 
 -- | Obtain information about the withdrawals of a specific account.
-getAccountWithdrawals :: Address -> BlockfrostClient [AccountWithdrawal]
+getAccountWithdrawals :: MonadBlockfrost m => Address -> m [AccountWithdrawal]
 getAccountWithdrawals a = getAccountWithdrawals' a def def
 
-getAccountMirs_ :: Project -> Address -> Paged -> SortOrder -> BlockfrostClient [AccountMir]
+getAccountMirs_ :: MonadBlockfrost m => Project -> Address -> Paged -> SortOrder -> m [AccountMir]
 getAccountMirs_ = _accountMirs . accountsClient
 
 -- | Obtain information about the MIRs of a specific account.
 -- Allows custom paging and ordering using @Paged@ and @SortOrder@.
-getAccountMirs' :: Address -> Paged -> SortOrder -> BlockfrostClient [AccountMir]
+getAccountMirs' :: MonadBlockfrost m => Address -> Paged -> SortOrder -> m [AccountMir]
 getAccountMirs' a pg s = go (\p -> getAccountMirs_ p a pg s)
 
 -- | Obtain information about the MIRs of a specific account.
-getAccountMirs :: Address -> BlockfrostClient [AccountMir]
+getAccountMirs :: MonadBlockfrost m => Address -> m [AccountMir]
 getAccountMirs a = getAccountMirs' a def def
 
-getAccountAssociatedAddresses_ :: Project -> Address -> Paged -> SortOrder -> BlockfrostClient [AddressAssociated]
+getAccountAssociatedAddresses_ :: MonadBlockfrost m => Project -> Address -> Paged -> SortOrder -> m [AddressAssociated]
 getAccountAssociatedAddresses_ = _accountAssociatedAddresses . accountsClient
 
 -- | Obtain information about the addresses of a specific account.
 -- Allows custom paging and ordering using @Paged@ and @SortOrder@.
-getAccountAssociatedAddresses' :: Address -> Paged -> SortOrder -> BlockfrostClient [AddressAssociated]
+getAccountAssociatedAddresses' :: MonadBlockfrost m => Address -> Paged -> SortOrder -> m [AddressAssociated]
 getAccountAssociatedAddresses' a pg s = go (\p -> getAccountAssociatedAddresses_ p a pg s)
 
 -- | Obtain information about the addresses of a specific account.
-getAccountAssociatedAddresses :: Address -> BlockfrostClient [AddressAssociated]
+getAccountAssociatedAddresses :: MonadBlockfrost m => Address -> m [AddressAssociated]
 getAccountAssociatedAddresses a = getAccountAssociatedAddresses' a def def
 
-getAccountAssociatedAssets_ :: Project -> Address -> Paged -> SortOrder -> BlockfrostClient [Amount]
+getAccountAssociatedAssets_ :: MonadBlockfrost m => Project -> Address -> Paged -> SortOrder -> m [Amount]
 getAccountAssociatedAssets_ = _accountAssociatedAssets . accountsClient
 
 -- | Obtain information about assets associated with addresses of a specific account.
 -- Allows custom paging and ordering using @Paged@ and @SortOrder@.
-getAccountAssociatedAssets' :: Address -> Paged -> SortOrder -> BlockfrostClient [Amount]
+getAccountAssociatedAssets' :: MonadBlockfrost m => Address -> Paged -> SortOrder -> m [Amount]
 getAccountAssociatedAssets' a pg s = go (\p -> getAccountAssociatedAssets_ p a pg s)
 
 -- | Obtain information about assets associated with addresses of a specific account.
-getAccountAssociatedAssets :: Address -> BlockfrostClient [Amount]
+getAccountAssociatedAssets :: MonadBlockfrost m => Address -> m [Amount]
 getAccountAssociatedAssets a = getAccountAssociatedAssets' a def def

--- a/blockfrost-client/src/Blockfrost/Client/Cardano/Addresses.hs
+++ b/blockfrost-client/src/Blockfrost/Client/Cardano/Addresses.hs
@@ -15,56 +15,56 @@ import Blockfrost.API
 import Blockfrost.Client.Types
 import Blockfrost.Types
 
-addressesClient :: Project -> AddressesAPI (AsClientT BlockfrostClient)
+addressesClient :: MonadBlockfrost m => Project -> AddressesAPI (AsClientT m)
 addressesClient = fromServant . _addresses . cardanoClient
 
-getAddressInfo_ :: Project -> Address -> BlockfrostClient AddressInfo
+getAddressInfo_ :: MonadBlockfrost m => Project -> Address -> m AddressInfo
 getAddressInfo_ = _addressInfo . addressesClient
 
 -- | Obtain information about a specific address.
-getAddressInfo :: Address -> BlockfrostClient AddressInfo
+getAddressInfo :: MonadBlockfrost m => Address -> m AddressInfo
 getAddressInfo a = go (`getAddressInfo_` a)
 
-getAddressDetails_ :: Project -> Address -> BlockfrostClient AddressDetails
+getAddressDetails_ :: MonadBlockfrost m => Project -> Address -> m AddressDetails
 getAddressDetails_ = _addressDetails . addressesClient
 
 -- | Obtain details about an address.
-getAddressDetails :: Address -> BlockfrostClient AddressDetails
+getAddressDetails :: MonadBlockfrost m => Address -> m AddressDetails
 getAddressDetails a = go (`getAddressDetails_` a)
 
-getAddressUtxos_ :: Project -> Address -> Paged -> SortOrder -> BlockfrostClient [AddressUtxo]
+getAddressUtxos_ :: MonadBlockfrost m => Project -> Address -> Paged -> SortOrder -> m [AddressUtxo]
 getAddressUtxos_ = _addressUtxos . addressesClient
 
 -- | UTXOs of the address.
 -- Allows custom paging and ordering using @Paged@ and @SortOrder@.
-getAddressUtxos' :: Address -> Paged -> SortOrder -> BlockfrostClient [AddressUtxo]
+getAddressUtxos' :: MonadBlockfrost m => Address -> Paged -> SortOrder -> m [AddressUtxo]
 getAddressUtxos' a pg s = go (\p -> getAddressUtxos_ p a pg s)
 
 -- | UTXOs of the address.
-getAddressUtxos :: Address -> BlockfrostClient [AddressUtxo]
+getAddressUtxos :: MonadBlockfrost m => Address -> m [AddressUtxo]
 getAddressUtxos a = getAddressUtxos' a def def
 
-getAddressUtxosAsset_ :: Project -> Address -> AssetId -> Paged -> SortOrder -> BlockfrostClient [AddressUtxo]
+getAddressUtxosAsset_ :: MonadBlockfrost m => Project -> Address -> AssetId -> Paged -> SortOrder -> m [AddressUtxo]
 getAddressUtxosAsset_ = _addressUtxosAsset . addressesClient
 
 -- | UTXOs of the address containing specific asset.
 -- Allows custom paging and ordering using @Paged@ and @SortOrder@.
-getAddressUtxosAsset' :: Address -> AssetId-> Paged -> SortOrder -> BlockfrostClient [AddressUtxo]
+getAddressUtxosAsset' :: MonadBlockfrost m => Address -> AssetId-> Paged -> SortOrder -> m [AddressUtxo]
 getAddressUtxosAsset' addr asset pg s = go (\p -> getAddressUtxosAsset_ p addr asset pg s)
 
 -- | UTXOs of the address containing specific asset.
-getAddressUtxosAsset :: Address -> AssetId -> BlockfrostClient [AddressUtxo]
+getAddressUtxosAsset :: MonadBlockfrost m => Address -> AssetId -> m [AddressUtxo]
 getAddressUtxosAsset addr asset = getAddressUtxosAsset' addr asset def def
 
 getAddressTransactions_ ::
---- Project -> Address -> BlockfrostClient [AddressTransaction]
-     Project
+     MonadBlockfrost m
+  => Project
   -> Address
   -> Paged
   -> SortOrder
   -> Maybe BlockIndex
   -> Maybe BlockIndex
-  -> BlockfrostClient [AddressTransaction]
+  -> m [AddressTransaction]
 getAddressTransactions_ = _addressTransactions . addressesClient
 
 -- | Transactions on the address.
@@ -72,14 +72,15 @@ getAddressTransactions_ = _addressTransactions . addressesClient
 -- Also allows support for limiting block ranges using `from`/`to`
 -- @BlockIndex@es.
 getAddressTransactions' ::
-     Address
+     MonadBlockfrost m
+  => Address
   -> Paged
   -> SortOrder
   -> Maybe BlockIndex
   -> Maybe BlockIndex
-  -> BlockfrostClient [AddressTransaction]
+  -> m [AddressTransaction]
 getAddressTransactions' a pg s from to = go (\p -> getAddressTransactions_ p a pg s from to)
 
 -- | Transactions on the address.
-getAddressTransactions :: Address -> BlockfrostClient [AddressTransaction]
+getAddressTransactions :: MonadBlockfrost m => Address -> m [AddressTransaction]
 getAddressTransactions a = getAddressTransactions' a def def Nothing Nothing

--- a/blockfrost-client/src/Blockfrost/Client/Cardano/Assets.hs
+++ b/blockfrost-client/src/Blockfrost/Client/Cardano/Assets.hs
@@ -18,72 +18,72 @@ import Blockfrost.API
 import Blockfrost.Client.Types
 import Blockfrost.Types
 
-assetsClient :: Project -> AssetsAPI (AsClientT BlockfrostClient)
+assetsClient :: MonadBlockfrost m => Project -> AssetsAPI (AsClientT m)
 assetsClient = fromServant . _assets . cardanoClient
 
-getAssets_ :: Project -> Paged -> SortOrder -> BlockfrostClient [AssetInfo]
+getAssets_ :: MonadBlockfrost m => Project -> Paged -> SortOrder -> m [AssetInfo]
 getAssets_ = _listAssets . assetsClient
 
 -- | List all assets
 -- Allows custom paging and ordering using @Paged@ and @SortOrder@.
-getAssets' :: Paged -> SortOrder -> BlockfrostClient [AssetInfo]
+getAssets' :: MonadBlockfrost m => Paged -> SortOrder -> m [AssetInfo]
 getAssets' pg s = go (\p -> getAssets_ p pg s)
 
 -- | List all assets
-getAssets :: BlockfrostClient [AssetInfo]
+getAssets :: MonadBlockfrost m => m [AssetInfo]
 getAssets = getAssets' def def
 
-getAssetDetails_ :: Project -> AssetId -> BlockfrostClient AssetDetails
+getAssetDetails_ :: MonadBlockfrost m => Project -> AssetId -> m AssetDetails
 getAssetDetails_ = _assetDetails . assetsClient
 
 -- | Information about a specific asset
-getAssetDetails :: AssetId -> BlockfrostClient AssetDetails
+getAssetDetails :: MonadBlockfrost m => AssetId -> m AssetDetails
 getAssetDetails a = go (`getAssetDetails_` a)
 
-getAssetHistory_ :: Project -> AssetId -> Paged -> SortOrder -> BlockfrostClient [AssetHistory]
+getAssetHistory_ :: MonadBlockfrost m => Project -> AssetId -> Paged -> SortOrder -> m [AssetHistory]
 getAssetHistory_ = _assetHistory . assetsClient
 
 -- | History of a specific asset
 -- Allows custom paging and ordering using @Paged@ and @SortOrder@.
-getAssetHistory' :: AssetId -> Paged -> SortOrder -> BlockfrostClient [AssetHistory]
+getAssetHistory' :: MonadBlockfrost m => AssetId -> Paged -> SortOrder -> m [AssetHistory]
 getAssetHistory' a pg s = go (\p -> getAssetHistory_ p a pg s)
 
 -- | History of a specific asset
-getAssetHistory :: AssetId -> BlockfrostClient [AssetHistory]
+getAssetHistory :: MonadBlockfrost m => AssetId -> m [AssetHistory]
 getAssetHistory a = getAssetHistory' a def def
 
-getAssetTransactions_ :: Project -> AssetId -> Paged -> SortOrder -> BlockfrostClient [AssetTransaction]
+getAssetTransactions_ :: MonadBlockfrost m => Project -> AssetId -> Paged -> SortOrder -> m [AssetTransaction]
 getAssetTransactions_ = _assetTransactions . assetsClient
 
 -- | List of a specific asset transactions
 -- Allows custom paging and ordering using @Paged@ and @SortOrder@.
-getAssetTransactions' :: AssetId -> Paged -> SortOrder -> BlockfrostClient [AssetTransaction]
+getAssetTransactions' :: MonadBlockfrost m => AssetId -> Paged -> SortOrder -> m [AssetTransaction]
 getAssetTransactions' a pg s = go (\p -> getAssetTransactions_ p a pg s)
 
 -- | List of a specific asset transactions
-getAssetTransactions :: AssetId -> BlockfrostClient [AssetTransaction]
+getAssetTransactions :: MonadBlockfrost m => AssetId -> m [AssetTransaction]
 getAssetTransactions a = getAssetTransactions' a def def
 
-getAssetAddresses_ :: Project -> AssetId -> Paged -> SortOrder -> BlockfrostClient [AssetAddress]
+getAssetAddresses_ :: MonadBlockfrost m => Project -> AssetId -> Paged -> SortOrder -> m [AssetAddress]
 getAssetAddresses_ = _assetAddresses . assetsClient
 
 -- | List of a addresses containing a specific asset
 -- Allows custom paging and ordering using @Paged@ and @SortOrder@.
-getAssetAddresses' :: AssetId -> Paged -> SortOrder -> BlockfrostClient [AssetAddress]
+getAssetAddresses' :: MonadBlockfrost m => AssetId -> Paged -> SortOrder -> m [AssetAddress]
 getAssetAddresses' a pg s = go (\p -> getAssetAddresses_ p a pg s)
 
 -- | List of a addresses containing a specific asset
-getAssetAddresses :: AssetId -> BlockfrostClient [AssetAddress]
+getAssetAddresses :: MonadBlockfrost m => AssetId -> m [AssetAddress]
 getAssetAddresses a = getAssetAddresses' a def def
 
-getAssetsByPolicy_ :: Project -> PolicyId -> Paged -> SortOrder -> BlockfrostClient [AssetInfo]
+getAssetsByPolicy_ :: MonadBlockfrost m => Project -> PolicyId -> Paged -> SortOrder -> m [AssetInfo]
 getAssetsByPolicy_ = _listAssetsPolicy . assetsClient
 
 -- | List of asset minted under a specific policy
 -- Allows custom paging and ordering using @Paged@ and @SortOrder@.
-getAssetsByPolicy' :: PolicyId -> Paged -> SortOrder -> BlockfrostClient [AssetInfo]
+getAssetsByPolicy' :: MonadBlockfrost m => PolicyId -> Paged -> SortOrder -> m [AssetInfo]
 getAssetsByPolicy' a pg s = go (\p -> getAssetsByPolicy_ p a pg s)
 
 -- | List of asset minted under a specific policy
-getAssetsByPolicy :: PolicyId -> BlockfrostClient [AssetInfo]
+getAssetsByPolicy :: MonadBlockfrost m => PolicyId -> m [AssetInfo]
 getAssetsByPolicy a = getAssetsByPolicy' a def def

--- a/blockfrost-client/src/Blockfrost/Client/Cardano/Blocks.hs
+++ b/blockfrost-client/src/Blockfrost/Client/Cardano/Blocks.hs
@@ -19,80 +19,80 @@ import Blockfrost.API
 import Blockfrost.Client.Types
 import Blockfrost.Types
 
-blocksClient :: Project -> BlocksAPI (AsClientT BlockfrostClient)
+blocksClient :: MonadBlockfrost m => Project -> BlocksAPI (AsClientT m)
 blocksClient = fromServant . _blocks . cardanoClient
 
-getLatestBlock_ :: Project -> BlockfrostClient Block
+getLatestBlock_ :: MonadBlockfrost m => Project -> m Block
 getLatestBlock_ = _latest . blocksClient
 
 -- | Return the latest block available to the backends, also known as the tip of the blockchain.
-getLatestBlock :: BlockfrostClient Block
+getLatestBlock :: MonadBlockfrost m => m Block
 getLatestBlock = go getLatestBlock_
 
-getLatestBlockTxs_ :: Project -> Paged -> SortOrder -> BlockfrostClient [TxHash]
+getLatestBlockTxs_ :: MonadBlockfrost m => Project -> Paged -> SortOrder -> m [TxHash]
 getLatestBlockTxs_ = _latestTxs . blocksClient
 
 -- | Return the transactions within the latest block.
 -- Allows custom paging and ordering using @Paged@ and @SortOrder@.
-getLatestBlockTxs' :: Paged -> SortOrder -> BlockfrostClient [TxHash]
+getLatestBlockTxs' :: MonadBlockfrost m => Paged -> SortOrder -> m [TxHash]
 getLatestBlockTxs' pg s = go (\p -> getLatestBlockTxs_ p pg s)
 
-getLatestBlockTxs :: BlockfrostClient [TxHash]
+getLatestBlockTxs :: MonadBlockfrost m => m [TxHash]
 getLatestBlockTxs = getLatestBlockTxs' def def
 
-getBlock_ :: Project -> Either Integer BlockHash -> BlockfrostClient Block
+getBlock_ :: MonadBlockfrost m => Project -> Either Integer BlockHash -> m Block
 getBlock_ = _block . blocksClient
 
 -- | Return the content of a requested block.
-getBlock :: Either Integer BlockHash -> BlockfrostClient Block
+getBlock :: MonadBlockfrost m => Either Integer BlockHash -> m Block
 getBlock a = go (`getBlock_` a)
 
-getBlockSlot_ :: Project -> Slot -> BlockfrostClient Block
+getBlockSlot_ :: MonadBlockfrost m => Project -> Slot -> m Block
 getBlockSlot_ = __blockSlot . blocksClient
 
 -- | Return the content of a requested block for a specific slot.
-getBlockSlot :: Slot -> BlockfrostClient Block
+getBlockSlot :: MonadBlockfrost m => Slot -> m Block
 getBlockSlot i = go (`getBlockSlot_` i)
 
-getBlockEpochSlot_ :: Project -> Epoch -> Slot -> BlockfrostClient Block
+getBlockEpochSlot_ :: MonadBlockfrost m => Project -> Epoch -> Slot -> m Block
 getBlockEpochSlot_ = __blockEpochSlot . blocksClient
 
 -- | Return the content of a requested block for a specific slot in an epoch.
-getBlockEpochSlot :: Epoch -> Slot -> BlockfrostClient Block
+getBlockEpochSlot :: MonadBlockfrost m => Epoch -> Slot -> m Block
 getBlockEpochSlot ep sl = go (\p -> getBlockEpochSlot_ p ep sl)
 
-getNextBlocks_ :: Project -> Either Integer BlockHash -> Paged -> BlockfrostClient [Block]
+getNextBlocks_ :: MonadBlockfrost m => Project -> Either Integer BlockHash -> Paged -> m [Block]
 getNextBlocks_ = _blockNext . blocksClient
 
 -- | Return the list of blocks following a specific block.
 -- Allows custom paging using @Paged@.
-getNextBlocks' :: Either Integer BlockHash -> Paged -> BlockfrostClient [Block]
+getNextBlocks' :: MonadBlockfrost m => Either Integer BlockHash -> Paged -> m [Block]
 getNextBlocks' a pg = go (\p -> getNextBlocks_ p a pg)
 
 -- | Return the list of blocks following a specific block.
-getNextBlocks :: Either Integer BlockHash -> BlockfrostClient [Block]
+getNextBlocks :: MonadBlockfrost m => Either Integer BlockHash -> m [Block]
 getNextBlocks a = getNextBlocks' a def
 
-getPreviousBlocks_ :: Project -> Either Integer BlockHash -> Paged -> BlockfrostClient [Block]
+getPreviousBlocks_ :: MonadBlockfrost m => Project -> Either Integer BlockHash -> Paged -> m [Block]
 getPreviousBlocks_ = _blockPrevious . blocksClient
 
 -- | Return the list of blocks preceding a specific block.
 -- Allows custom paging using @Paged@.
-getPreviousBlocks' :: Either Integer BlockHash -> Paged -> BlockfrostClient [Block]
+getPreviousBlocks' :: MonadBlockfrost m => Either Integer BlockHash -> Paged -> m [Block]
 getPreviousBlocks' a pg = go (\p -> getPreviousBlocks_ p a pg)
 
 -- | Return the list of blocks preceding a specific block.
-getPreviousBlocks :: Either Integer BlockHash -> BlockfrostClient [Block]
+getPreviousBlocks :: MonadBlockfrost m => Either Integer BlockHash -> m [Block]
 getPreviousBlocks a = getPreviousBlocks' a def
 
-getBlockTxs_ :: Project -> Either Integer BlockHash -> Paged -> SortOrder -> BlockfrostClient [TxHash]
+getBlockTxs_ :: MonadBlockfrost m => Project -> Either Integer BlockHash -> Paged -> SortOrder -> m [TxHash]
 getBlockTxs_ = _blockTxs . blocksClient
 
 -- | Return the transactions within the block.
 -- Allows custom paging and ordering using @Paged@ and @SortOrder@.
-getBlockTxs' :: Either Integer BlockHash -> Paged -> SortOrder -> BlockfrostClient [TxHash]
+getBlockTxs' :: MonadBlockfrost m => Either Integer BlockHash -> Paged -> SortOrder -> m [TxHash]
 getBlockTxs' a pg s = go (\p -> getBlockTxs_ p a pg s)
 
 -- | Return the transactions within the block.
-getBlockTxs :: Either Integer BlockHash -> BlockfrostClient [TxHash]
+getBlockTxs :: MonadBlockfrost m => Either Integer BlockHash -> m [TxHash]
 getBlockTxs a = getBlockTxs' a def def

--- a/blockfrost-client/src/Blockfrost/Client/Cardano/Epochs.hs
+++ b/blockfrost-client/src/Blockfrost/Client/Cardano/Epochs.hs
@@ -24,105 +24,105 @@ import Blockfrost.Client.Types
 import Blockfrost.Types
 
 
-epochsClient :: Project -> EpochsAPI (AsClientT BlockfrostClient)
+epochsClient :: MonadBlockfrost m => Project -> EpochsAPI (AsClientT m)
 epochsClient = fromServant . _epochs . cardanoClient
 
-getLatestEpoch_ :: Project -> BlockfrostClient EpochInfo
+getLatestEpoch_ :: MonadBlockfrost m => Project -> m EpochInfo
 getLatestEpoch_ = _latestEpoch . epochsClient
 
 -- | Get the information about the latest, therefore current, epoch.
-getLatestEpoch :: BlockfrostClient EpochInfo
+getLatestEpoch :: MonadBlockfrost m => m EpochInfo
 getLatestEpoch = go getLatestEpoch_
 
-getLatestEpochProtocolParams_ :: Project -> BlockfrostClient ProtocolParams
+getLatestEpochProtocolParams_ :: MonadBlockfrost m => Project -> m ProtocolParams
 getLatestEpochProtocolParams_ = _latestEpochProtocolParams . epochsClient
 
 -- | Get the protocol parameters for the latest epoch.
-getLatestEpochProtocolParams :: BlockfrostClient ProtocolParams
+getLatestEpochProtocolParams :: MonadBlockfrost m => m ProtocolParams
 getLatestEpochProtocolParams = go getLatestEpochProtocolParams_
 
-getEpoch_ :: Project -> Epoch -> BlockfrostClient EpochInfo
+getEpoch_ :: MonadBlockfrost m => Project -> Epoch -> m EpochInfo
 getEpoch_ = _getEpoch . epochsClient
 
 -- | Get the information about specific epoch.
-getEpoch :: Epoch -> BlockfrostClient EpochInfo
+getEpoch :: MonadBlockfrost m => Epoch -> m EpochInfo
 getEpoch e = go (`getEpoch_` e)
 
-getNextEpochs_ :: Project -> Epoch -> Paged -> BlockfrostClient [EpochInfo]
+getNextEpochs_ :: MonadBlockfrost m => Project -> Epoch -> Paged -> m [EpochInfo]
 getNextEpochs_ = _getNextEpochs . epochsClient
 
 -- | Return the list of epochs following a specific epoch.
 -- Allows custom paging using @Paged@.
-getNextEpochs' :: Epoch -> Paged -> BlockfrostClient [EpochInfo]
+getNextEpochs' :: MonadBlockfrost m => Epoch -> Paged -> m [EpochInfo]
 getNextEpochs' e pg = go (\p -> getNextEpochs_ p e pg)
 
 -- | Return the list of epochs following a specific epoch.
-getNextEpochs :: Epoch -> BlockfrostClient [EpochInfo]
+getNextEpochs :: MonadBlockfrost m => Epoch -> m [EpochInfo]
 getNextEpochs e = getNextEpochs' e def
 
-getPreviousEpochs_ :: Project -> Epoch -> Paged -> BlockfrostClient [EpochInfo]
+getPreviousEpochs_ :: MonadBlockfrost m => Project -> Epoch -> Paged -> m [EpochInfo]
 getPreviousEpochs_ = _getPreviousEpochs . epochsClient
 
 -- | Return the list of epochs preceding a specific epoch.
 -- Allows custom paging using @Paged@.
-getPreviousEpochs' :: Epoch -> Paged -> BlockfrostClient [EpochInfo]
+getPreviousEpochs' :: MonadBlockfrost m => Epoch -> Paged -> m [EpochInfo]
 getPreviousEpochs' e pg = go (\p -> getPreviousEpochs_ p e pg)
 
 -- | Return the list of epochs preceding a specific epoch.
-getPreviousEpochs :: Epoch -> BlockfrostClient [EpochInfo]
+getPreviousEpochs :: MonadBlockfrost m => Epoch -> m [EpochInfo]
 getPreviousEpochs e = getPreviousEpochs' e def
 
-getEpochStake_ :: Project -> Epoch -> Paged -> BlockfrostClient [StakeDistribution]
+getEpochStake_ :: MonadBlockfrost m => Project -> Epoch -> Paged -> m [StakeDistribution]
 getEpochStake_ = _getEpochStake . epochsClient
 
 -- | Return the active stake distribution for the specified epoch.
 -- Allows custom paging using @Paged@.
-getEpochStake' :: Epoch -> Paged -> BlockfrostClient [StakeDistribution]
+getEpochStake' :: MonadBlockfrost m => Epoch -> Paged -> m [StakeDistribution]
 getEpochStake' e pg = go (\p -> getEpochStake_ p e pg)
 
 -- | Return the active stake distribution for the specified epoch.
-getEpochStake :: Epoch -> BlockfrostClient [StakeDistribution]
+getEpochStake :: MonadBlockfrost m => Epoch -> m [StakeDistribution]
 getEpochStake e = getEpochStake' e def
 
-getEpochStakeByPool_ :: Project -> Epoch -> PoolId -> Paged -> BlockfrostClient [StakeDistribution]
+getEpochStakeByPool_ :: MonadBlockfrost m => Project -> Epoch -> PoolId -> Paged -> m [StakeDistribution]
 getEpochStakeByPool_ = _getEpochStakeByPool . epochsClient
 
 -- | Return the active stake distribution for the epoch specified by stake pool.
 -- Allows custom paging using @Paged@.
-getEpochStakeByPool' :: Epoch -> PoolId -> Paged -> BlockfrostClient [StakeDistribution]
+getEpochStakeByPool' :: MonadBlockfrost m => Epoch -> PoolId -> Paged -> m [StakeDistribution]
 getEpochStakeByPool' e i pg = go (\p -> getEpochStakeByPool_ p e i pg)
 
 -- | Return the active stake distribution for the epoch specified by stake pool.
-getEpochStakeByPool :: Epoch -> PoolId -> BlockfrostClient [StakeDistribution]
+getEpochStakeByPool :: MonadBlockfrost m => Epoch -> PoolId -> m [StakeDistribution]
 getEpochStakeByPool e i = getEpochStakeByPool' e i def
 
-getEpochBlocks_ :: Project -> Epoch -> Paged -> SortOrder -> BlockfrostClient [BlockHash]
+getEpochBlocks_ :: MonadBlockfrost m => Project -> Epoch -> Paged -> SortOrder -> m [BlockHash]
 getEpochBlocks_ = _getEpochBlocks . epochsClient
 
 -- | Return the blocks minted for the epoch specified.
 -- Allows custom paging and ordering using @Paged@ and @SortOrder@.
-getEpochBlocks' :: Epoch -> Paged -> SortOrder -> BlockfrostClient [BlockHash]
+getEpochBlocks' :: MonadBlockfrost m => Epoch -> Paged -> SortOrder -> m [BlockHash]
 getEpochBlocks' e pg s = go (\p -> getEpochBlocks_ p e pg s)
 
 -- | Return the blocks minted for the epoch specified.
-getEpochBlocks :: Epoch -> BlockfrostClient [BlockHash]
+getEpochBlocks :: MonadBlockfrost m => Epoch -> m [BlockHash]
 getEpochBlocks e = getEpochBlocks' e def def
 
-getEpochBlocksByPool_ :: Project -> Epoch -> PoolId -> Paged -> SortOrder -> BlockfrostClient [BlockHash]
+getEpochBlocksByPool_ :: MonadBlockfrost m => Project -> Epoch -> PoolId -> Paged -> SortOrder -> m [BlockHash]
 getEpochBlocksByPool_ = _getEpochBlocksByPool . epochsClient
 
 -- | Return the block minted for the epoch specified by stake pool.
 -- Allows custom paging and ordering using @Paged@ and @SortOrder@.
-getEpochBlocksByPool' :: Epoch -> PoolId -> Paged -> SortOrder -> BlockfrostClient [BlockHash]
+getEpochBlocksByPool' :: MonadBlockfrost m => Epoch -> PoolId -> Paged -> SortOrder -> m [BlockHash]
 getEpochBlocksByPool' e i pg s = go (\p -> getEpochBlocksByPool_ p e i pg s)
 
 -- | Return the block minted for the epoch specified by stake pool.
-getEpochBlocksByPool :: Epoch -> PoolId -> BlockfrostClient [BlockHash]
+getEpochBlocksByPool :: MonadBlockfrost m => Epoch -> PoolId -> m [BlockHash]
 getEpochBlocksByPool e i = getEpochBlocksByPool' e i def def
 
-getEpochProtocolParams_ :: Project -> Epoch -> BlockfrostClient ProtocolParams
+getEpochProtocolParams_ :: MonadBlockfrost m => Project -> Epoch -> m ProtocolParams
 getEpochProtocolParams_ = _getEpochProtocolParams . epochsClient
 
 -- | Return the protocol parameters for the specified epoch.
-getEpochProtocolParams :: Epoch -> BlockfrostClient ProtocolParams
+getEpochProtocolParams :: MonadBlockfrost m => Epoch -> m ProtocolParams
 getEpochProtocolParams e = go (`getEpochProtocolParams_` e)

--- a/blockfrost-client/src/Blockfrost/Client/Cardano/Ledger.hs
+++ b/blockfrost-client/src/Blockfrost/Client/Cardano/Ledger.hs
@@ -8,12 +8,12 @@ import Blockfrost.API
 import Blockfrost.Client.Types
 import Blockfrost.Types
 
-ledgerClient :: Project -> LedgerAPI (AsClientT BlockfrostClient)
+ledgerClient :: MonadBlockfrost m => Project -> LedgerAPI (AsClientT m)
 ledgerClient = fromServant . _ledger . cardanoClient
 
-getLedgerGenesis_ :: Project -> BlockfrostClient Genesis
+getLedgerGenesis_ :: MonadBlockfrost m => Project -> m Genesis
 getLedgerGenesis_ = _genesis . ledgerClient
 
 -- | Get the information about blockchain genesis.
-getLedgerGenesis:: BlockfrostClient Genesis
+getLedgerGenesis :: MonadBlockfrost m => m Genesis
 getLedgerGenesis = go getLedgerGenesis_

--- a/blockfrost-client/src/Blockfrost/Client/Cardano/Metadata.hs
+++ b/blockfrost-client/src/Blockfrost/Client/Cardano/Metadata.hs
@@ -14,41 +14,41 @@ import Blockfrost.Client.Types
 import Blockfrost.Types
 import Data.Text (Text)
 
-metadataClient :: Project -> MetadataAPI (AsClientT BlockfrostClient)
+metadataClient :: MonadBlockfrost m => Project -> MetadataAPI (AsClientT m)
 metadataClient = fromServant . _metadata . cardanoClient
 
-getTxMetadataLabels_ :: Project -> Paged -> SortOrder -> BlockfrostClient [TxMeta]
+getTxMetadataLabels_ :: MonadBlockfrost m => Project -> Paged -> SortOrder -> m [TxMeta]
 getTxMetadataLabels_ = _txMetadataLabels . metadataClient
 
 -- | List of all used transaction metadata labels.
 -- Allows custom paging and ordering using @Paged@ and @SortOrder@.
-getTxMetadataLabels' :: Paged -> SortOrder -> BlockfrostClient [TxMeta]
+getTxMetadataLabels' :: MonadBlockfrost m => Paged -> SortOrder -> m [TxMeta]
 getTxMetadataLabels' pg s = go (\p -> getTxMetadataLabels_ p pg s)
 
 -- | List of all used transaction metadata labels.
-getTxMetadataLabels :: BlockfrostClient [TxMeta]
+getTxMetadataLabels :: MonadBlockfrost m => m [TxMeta]
 getTxMetadataLabels = getTxMetadataLabels' def def
 
-getTxMetadataByLabelJSON_ :: Project -> Text -> Paged -> SortOrder -> BlockfrostClient [TxMetaJSON]
+getTxMetadataByLabelJSON_ :: MonadBlockfrost m => Project -> Text -> Paged -> SortOrder -> m [TxMetaJSON]
 getTxMetadataByLabelJSON_ = _txMetadataByLabelJSON . metadataClient
 
 -- | Transaction metadata per label (JSON @Value@)
 -- Allows custom paging and ordering using @Paged@ and @SortOrder@.
-getTxMetadataByLabelJSON' :: Text -> Paged -> SortOrder -> BlockfrostClient [TxMetaJSON]
+getTxMetadataByLabelJSON' :: MonadBlockfrost m => Text -> Paged -> SortOrder -> m [TxMetaJSON]
 getTxMetadataByLabelJSON' t pg s = go (\p -> getTxMetadataByLabelJSON_ p t pg s)
 
 -- | Transaction metadata per label (JSON @Value@)
-getTxMetadataByLabelJSON :: Text -> BlockfrostClient [TxMetaJSON]
+getTxMetadataByLabelJSON :: MonadBlockfrost m => Text -> m [TxMetaJSON]
 getTxMetadataByLabelJSON t = getTxMetadataByLabelJSON' t def def
 
-getTxMetadataByLabelCBOR_ :: Project -> Text -> Paged -> SortOrder -> BlockfrostClient [TxMetaCBOR]
+getTxMetadataByLabelCBOR_ :: MonadBlockfrost m => Project -> Text -> Paged -> SortOrder -> m [TxMetaCBOR]
 getTxMetadataByLabelCBOR_ = _txMetadataByLabelCBOR . metadataClient
 
 -- | Transaction metadata per label (CBOR @ByteString@)
 -- Allows custom paging and ordering using @Paged@ and @SortOrder@.
-getTxMetadataByLabelCBOR' :: Text -> Paged -> SortOrder -> BlockfrostClient [TxMetaCBOR]
+getTxMetadataByLabelCBOR' :: MonadBlockfrost m => Text -> Paged -> SortOrder -> m [TxMetaCBOR]
 getTxMetadataByLabelCBOR' t pg s = go (\p -> getTxMetadataByLabelCBOR_ p t pg s)
 
 -- | Transaction metadata per label (CBOR @ByteString@)
-getTxMetadataByLabelCBOR :: Text -> BlockfrostClient [TxMetaCBOR]
+getTxMetadataByLabelCBOR :: MonadBlockfrost m => Text -> m [TxMetaCBOR]
 getTxMetadataByLabelCBOR t = getTxMetadataByLabelCBOR' t def def

--- a/blockfrost-client/src/Blockfrost/Client/Cardano/Network.hs
+++ b/blockfrost-client/src/Blockfrost/Client/Cardano/Network.hs
@@ -9,12 +9,12 @@ import Blockfrost.Client.Types
 import Blockfrost.Types
 
 
-networkClient :: Project -> NetworkAPI (AsClientT BlockfrostClient)
+networkClient :: MonadBlockfrost m => Project -> NetworkAPI (AsClientT m)
 networkClient = fromServant . _network . cardanoClient
 
-getNetworkInfo_ :: Project -> BlockfrostClient Network
+getNetworkInfo_ :: MonadBlockfrost m => Project -> m Network
 getNetworkInfo_ = _networkInfo . networkClient
 
 -- | Get detailed network information.
-getNetworkInfo:: BlockfrostClient Network
+getNetworkInfo :: MonadBlockfrost m => m Network
 getNetworkInfo = go getNetworkInfo_

--- a/blockfrost-client/src/Blockfrost/Client/Cardano/Pools.hs
+++ b/blockfrost-client/src/Blockfrost/Client/Cardano/Pools.hs
@@ -24,110 +24,110 @@ import Blockfrost.API
 import Blockfrost.Client.Types
 import Blockfrost.Types
 
-poolsClient :: Project -> PoolsAPI (AsClientT BlockfrostClient)
+poolsClient :: MonadBlockfrost m => Project -> PoolsAPI (AsClientT m)
 poolsClient = fromServant . _pools . cardanoClient
 
-listPools_ :: Project -> Paged -> SortOrder -> BlockfrostClient [PoolId]
+listPools_ :: MonadBlockfrost m => Project -> Paged -> SortOrder -> m [PoolId]
 listPools_ = _listPools . poolsClient
 
 -- | List registered stake pools.
 -- Allows custom paging and ordering using @Paged@ and @SortOrder@.
-listPools' :: Paged -> SortOrder -> BlockfrostClient [PoolId]
+listPools' :: MonadBlockfrost m => Paged -> SortOrder -> m [PoolId]
 listPools' pg s = go (\p -> listPools_ p pg s)
 
 -- | List registered stake pools.
-listPools :: BlockfrostClient [PoolId]
+listPools :: MonadBlockfrost m => m [PoolId]
 listPools = listPools' def def
 
-listRetiredPools_ :: Project -> Paged -> SortOrder -> BlockfrostClient [PoolEpoch]
+listRetiredPools_ :: MonadBlockfrost m => Project -> Paged -> SortOrder -> m [PoolEpoch]
 listRetiredPools_ = _listRetiredPools . poolsClient
 
 -- | List retired stake pools.
 -- Allows custom paging and ordering using @Paged@ and @SortOrder@.
-listRetiredPools' :: Paged -> SortOrder -> BlockfrostClient [PoolEpoch]
+listRetiredPools' :: MonadBlockfrost m => Paged -> SortOrder -> m [PoolEpoch]
 listRetiredPools' pg s = go (\p -> listRetiredPools_ p pg s)
 
 -- | List retired stake pools.
-listRetiredPools :: BlockfrostClient [PoolEpoch]
+listRetiredPools :: MonadBlockfrost m => m [PoolEpoch]
 listRetiredPools = listRetiredPools' def def
 
-listRetiringPools_ :: Project -> Paged -> SortOrder -> BlockfrostClient [PoolEpoch]
+listRetiringPools_ :: MonadBlockfrost m => Project -> Paged -> SortOrder -> m [PoolEpoch]
 listRetiringPools_ = _listRetiringPools . poolsClient
 
 -- | List retiring stake pools.
 -- Allows custom paging and ordering using @Paged@ and @SortOrder@.
-listRetiringPools' :: Paged -> SortOrder -> BlockfrostClient [PoolEpoch]
+listRetiringPools' :: MonadBlockfrost m => Paged -> SortOrder -> m [PoolEpoch]
 listRetiringPools' pg s = go (\p -> listRetiringPools_ p pg s)
 
 -- | List retiring stake pools.
-listRetiringPools :: BlockfrostClient [PoolEpoch]
+listRetiringPools :: MonadBlockfrost m => m [PoolEpoch]
 listRetiringPools = listRetiringPools' def def
 
-getPool_ :: Project -> PoolId -> BlockfrostClient PoolInfo
+getPool_ :: MonadBlockfrost m => Project -> PoolId -> m PoolInfo
 getPool_ = _getPool . poolsClient
 
 -- | Get specific stake pool information
-getPool:: PoolId -> BlockfrostClient PoolInfo
+getPool :: MonadBlockfrost m => PoolId -> m PoolInfo
 getPool p = go (`getPool_` p)
 
-getPoolHistory_ :: Project -> PoolId -> Paged -> SortOrder -> BlockfrostClient [PoolHistory]
+getPoolHistory_ :: MonadBlockfrost m => Project -> PoolId -> Paged -> SortOrder -> m [PoolHistory]
 getPoolHistory_ = _getPoolHistory . poolsClient
 
 -- | Get stake pool history
 -- Allows custom paging and ordering using @Paged@ and @SortOrder@.
-getPoolHistory' :: PoolId -> Paged -> SortOrder -> BlockfrostClient [PoolHistory]
+getPoolHistory' :: MonadBlockfrost m => PoolId -> Paged -> SortOrder -> m [PoolHistory]
 getPoolHistory' pid pg s = go (\p -> getPoolHistory_ p pid pg s)
 
 -- | Get stake pool history
-getPoolHistory :: PoolId -> BlockfrostClient [PoolHistory]
+getPoolHistory :: MonadBlockfrost m => PoolId -> m [PoolHistory]
 getPoolHistory p = getPoolHistory' p def def
 
-getPoolMetadata_ :: Project -> PoolId -> BlockfrostClient (Maybe PoolMetadata)
+getPoolMetadata_ :: MonadBlockfrost m => Project -> PoolId -> m (Maybe PoolMetadata)
 getPoolMetadata_ = _getPoolMetadata . poolsClient
 
 -- | Get stake pool metadata
-getPoolMetadata :: PoolId -> BlockfrostClient (Maybe PoolMetadata)
+getPoolMetadata :: MonadBlockfrost m => PoolId -> m (Maybe PoolMetadata)
 getPoolMetadata p = go (`getPoolMetadata_` p)
 
-getPoolRelays_ :: Project -> PoolId -> BlockfrostClient [PoolRelay]
+getPoolRelays_ :: MonadBlockfrost m => Project -> PoolId -> m [PoolRelay]
 getPoolRelays_ = _getPoolRelays . poolsClient
 
 -- | Get stake pool relays
-getPoolRelays :: PoolId -> BlockfrostClient [PoolRelay]
+getPoolRelays :: MonadBlockfrost m => PoolId -> m [PoolRelay]
 getPoolRelays p = go (`getPoolRelays_` p)
 
-getPoolDelegators_ :: Project -> PoolId -> Paged -> SortOrder -> BlockfrostClient [PoolDelegator]
+getPoolDelegators_ :: MonadBlockfrost m => Project -> PoolId -> Paged -> SortOrder -> m [PoolDelegator]
 getPoolDelegators_ = _getPoolDelegators . poolsClient
 
 -- | Get stake pool delegators
 -- Allows custom paging and ordering using @Paged@ and @SortOrder@.
-getPoolDelegators' :: PoolId -> Paged -> SortOrder -> BlockfrostClient [PoolDelegator]
+getPoolDelegators' :: MonadBlockfrost m => PoolId -> Paged -> SortOrder -> m [PoolDelegator]
 getPoolDelegators' pid pg s = go (\p -> getPoolDelegators_ p pid pg s)
 
 -- | Get stake pool delegators
-getPoolDelegators :: PoolId -> BlockfrostClient [PoolDelegator]
+getPoolDelegators :: MonadBlockfrost m => PoolId -> m [PoolDelegator]
 getPoolDelegators p = getPoolDelegators' p def def
 
-getPoolBlocks_ :: Project -> PoolId -> Paged -> SortOrder -> BlockfrostClient [BlockHash]
+getPoolBlocks_ :: MonadBlockfrost m => Project -> PoolId -> Paged -> SortOrder -> m [BlockHash]
 getPoolBlocks_ = _getPoolBlocks . poolsClient
 
 -- | Get stake pool blocks
 -- Allows custom paging and ordering using @Paged@ and @SortOrder@.
-getPoolBlocks' :: PoolId -> Paged -> SortOrder -> BlockfrostClient [BlockHash]
+getPoolBlocks' :: MonadBlockfrost m => PoolId -> Paged -> SortOrder -> m [BlockHash]
 getPoolBlocks' pid pg s = go (\p -> getPoolBlocks_ p pid pg s)
 
 -- | Get stake pool blocks
-getPoolBlocks :: PoolId -> BlockfrostClient [BlockHash]
+getPoolBlocks :: MonadBlockfrost m => PoolId -> m [BlockHash]
 getPoolBlocks p = getPoolBlocks' p def def
 
-getPoolUpdates_ :: Project -> PoolId -> Paged -> SortOrder -> BlockfrostClient [PoolUpdate]
+getPoolUpdates_ :: MonadBlockfrost m => Project -> PoolId -> Paged -> SortOrder -> m [PoolUpdate]
 getPoolUpdates_ = _getPoolUpdates . poolsClient
 
 -- | Get stake pool updates
 -- Allows custom paging and ordering using @Paged@ and @SortOrder@.
-getPoolUpdates' :: PoolId -> Paged -> SortOrder -> BlockfrostClient [PoolUpdate]
+getPoolUpdates' :: MonadBlockfrost m => PoolId -> Paged -> SortOrder -> m [PoolUpdate]
 getPoolUpdates' pid pg s = go (\p -> getPoolUpdates_ p pid pg s)
 
 -- | Get stake pool updates
-getPoolUpdates :: PoolId -> BlockfrostClient [PoolUpdate]
+getPoolUpdates :: MonadBlockfrost m => PoolId -> m [PoolUpdate]
 getPoolUpdates p = getPoolUpdates' p def def

--- a/blockfrost-client/src/Blockfrost/Client/Cardano/Scripts.hs
+++ b/blockfrost-client/src/Blockfrost/Client/Cardano/Scripts.hs
@@ -15,57 +15,57 @@ import Blockfrost.API
 import Blockfrost.Client.Types
 import Blockfrost.Types
 
-scriptsClient :: Project -> ScriptsAPI (AsClientT BlockfrostClient)
+scriptsClient :: MonadBlockfrost m => Project -> ScriptsAPI (AsClientT m)
 scriptsClient = fromServant . _scripts . cardanoClient
 
-listScripts_ :: Project -> Paged -> SortOrder -> BlockfrostClient [ScriptHash]
+listScripts_ :: MonadBlockfrost m => Project -> Paged -> SortOrder -> m [ScriptHash]
 listScripts_ = _listScripts . scriptsClient
 
 -- | List scripts
 -- Allows custom paging and ordering using @Paged@ and @SortOrder@.
-listScripts' :: Paged -> SortOrder -> BlockfrostClient [ScriptHash]
+listScripts' :: MonadBlockfrost m => Paged -> SortOrder -> m [ScriptHash]
 listScripts' pg s = go (\p -> listScripts_ p pg s)
 
 -- | List scripts
-listScripts :: BlockfrostClient [ScriptHash]
+listScripts :: MonadBlockfrost m => m [ScriptHash]
 listScripts = listScripts' def def
 
-getScript_ :: Project -> ScriptHash -> BlockfrostClient Script
+getScript_ :: MonadBlockfrost m => Project -> ScriptHash -> m Script
 getScript_ = _getScript . scriptsClient
 
 -- | Get specific script information
-getScript:: ScriptHash -> BlockfrostClient Script
+getScript :: MonadBlockfrost m => ScriptHash -> m Script
 getScript sh = go (`getScript_` sh)
 
-getScriptRedeemers_ :: Project -> ScriptHash -> Paged -> SortOrder -> BlockfrostClient [ScriptRedeemer]
+getScriptRedeemers_ :: MonadBlockfrost m => Project -> ScriptHash -> Paged -> SortOrder -> m [ScriptRedeemer]
 getScriptRedeemers_ = _getScriptRedeemers . scriptsClient
 
 -- | Get redeemers of a specific script
 -- Allows custom paging and ordering using @Paged@ and @SortOrder@.
-getScriptRedeemers' :: ScriptHash -> Paged -> SortOrder -> BlockfrostClient [ScriptRedeemer]
+getScriptRedeemers' :: MonadBlockfrost m => ScriptHash -> Paged -> SortOrder -> m [ScriptRedeemer]
 getScriptRedeemers' sh pg s = go (\p -> getScriptRedeemers_ p sh pg s)
 
 -- | Get redeemers of a specific script
-getScriptRedeemers :: ScriptHash -> BlockfrostClient [ScriptRedeemer]
+getScriptRedeemers :: MonadBlockfrost m => ScriptHash -> m [ScriptRedeemer]
 getScriptRedeemers sh = getScriptRedeemers' sh def def
 
-getScriptDatum_ :: Project -> DatumHash -> BlockfrostClient ScriptDatum
+getScriptDatum_ :: MonadBlockfrost m => Project -> DatumHash -> m ScriptDatum
 getScriptDatum_ = _getScriptDatum . scriptsClient
 
 -- | Get specific datum
-getScriptDatum :: DatumHash -> BlockfrostClient ScriptDatum
+getScriptDatum :: MonadBlockfrost m => DatumHash -> m ScriptDatum
 getScriptDatum sh = go (`getScriptDatum_` sh)
 
-getScriptJSON_ :: Project -> ScriptHash -> BlockfrostClient ScriptJSON
+getScriptJSON_ :: MonadBlockfrost m => Project -> ScriptHash -> m ScriptJSON
 getScriptJSON_ = _getScriptJSON . scriptsClient
 
 -- | Get a JSON representation of a `timelock` script
-getScriptJSON :: ScriptHash -> BlockfrostClient ScriptJSON
+getScriptJSON :: MonadBlockfrost m => ScriptHash -> m ScriptJSON
 getScriptJSON sh = go (`getScriptJSON_` sh)
 
-getScriptCBOR_ :: Project -> ScriptHash -> BlockfrostClient ScriptCBOR
+getScriptCBOR_ :: MonadBlockfrost m => Project -> ScriptHash -> m ScriptCBOR
 getScriptCBOR_ = _getScriptCBOR . scriptsClient
 
 -- | Get a CBOR representation of a `plutus` script
-getScriptCBOR :: ScriptHash -> BlockfrostClient ScriptCBOR
+getScriptCBOR :: MonadBlockfrost m => ScriptHash -> m ScriptCBOR
 getScriptCBOR sh = go (`getScriptCBOR_` sh)

--- a/blockfrost-client/src/Blockfrost/Client/Cardano/Transactions.hs
+++ b/blockfrost-client/src/Blockfrost/Client/Cardano/Transactions.hs
@@ -19,89 +19,89 @@ import Blockfrost.API
 import Blockfrost.Client.Types
 import Blockfrost.Types
 
-transactionsClient :: Project -> TransactionsAPI (AsClientT BlockfrostClient)
+transactionsClient :: MonadBlockfrost m => Project -> TransactionsAPI (AsClientT m)
 transactionsClient = fromServant . _transactions . cardanoClient
 
-getTx_ :: Project -> TxHash -> BlockfrostClient Transaction
+getTx_ :: MonadBlockfrost m => Project -> TxHash -> m Transaction
 getTx_ = _tx . transactionsClient
 
 -- | Get specific transaction
-getTx :: TxHash -> BlockfrostClient Transaction
+getTx :: MonadBlockfrost m => TxHash -> m Transaction
 getTx t = go (`getTx_` t)
 
-getTxUtxos_ :: Project -> TxHash -> BlockfrostClient TransactionUtxos
+getTxUtxos_ :: MonadBlockfrost m => Project -> TxHash -> m TransactionUtxos
 getTxUtxos_ = _txUtxos . transactionsClient
 
 -- | Get transaction UTXOs
-getTxUtxos :: TxHash -> BlockfrostClient TransactionUtxos
+getTxUtxos :: MonadBlockfrost m => TxHash -> m TransactionUtxos
 getTxUtxos t = go (`getTxUtxos_` t)
 
-getTxRedeemers_ :: Project -> TxHash -> BlockfrostClient [TransactionRedeemer]
+getTxRedeemers_ :: MonadBlockfrost m => Project -> TxHash -> m [TransactionRedeemer]
 getTxRedeemers_ = _txRedeemers . transactionsClient
 
 -- | Get transaction redeemers
-getTxRedeemers :: TxHash -> BlockfrostClient [TransactionRedeemer]
+getTxRedeemers :: MonadBlockfrost m => TxHash -> m [TransactionRedeemer]
 getTxRedeemers t = go (`getTxRedeemers_` t)
 
-getTxStakes_ :: Project -> TxHash -> BlockfrostClient [TransactionStake]
+getTxStakes_ :: MonadBlockfrost m => Project -> TxHash -> m [TransactionStake]
 getTxStakes_ = _txStakes . transactionsClient
 
 -- | Get transaction UTXOs
-getTxStakes :: TxHash -> BlockfrostClient [TransactionStake]
+getTxStakes :: MonadBlockfrost m => TxHash -> m [TransactionStake]
 getTxStakes t = go (`getTxStakes_` t)
 
-getTxDelegations_ :: Project -> TxHash -> BlockfrostClient [TransactionDelegation]
+getTxDelegations_ :: MonadBlockfrost m => Project -> TxHash -> m [TransactionDelegation]
 getTxDelegations_ = _txDelegations . transactionsClient
 
 -- | Get transaction delegation certificates
-getTxDelegations :: TxHash -> BlockfrostClient [TransactionDelegation]
+getTxDelegations :: MonadBlockfrost m => TxHash -> m [TransactionDelegation]
 getTxDelegations t = go (`getTxDelegations_` t)
 
-getTxWithdrawals_ :: Project -> TxHash -> BlockfrostClient [TransactionWithdrawal]
+getTxWithdrawals_ :: MonadBlockfrost m => Project -> TxHash -> m [TransactionWithdrawal]
 getTxWithdrawals_ = _txWithdrawals . transactionsClient
 
 -- | Get transaction withdrawals
-getTxWithdrawals :: TxHash -> BlockfrostClient [TransactionWithdrawal]
+getTxWithdrawals :: MonadBlockfrost m => TxHash -> m [TransactionWithdrawal]
 getTxWithdrawals t = go (`getTxWithdrawals_` t)
 
-getTxMirs_ :: Project -> TxHash -> BlockfrostClient [TransactionMir]
+getTxMirs_ :: MonadBlockfrost m => Project -> TxHash -> m [TransactionMir]
 getTxMirs_ = _txMirs . transactionsClient
 
 -- | Get transaction MIRs (Move Instantaneous Rewards)
-getTxMirs :: TxHash -> BlockfrostClient [TransactionMir]
+getTxMirs :: MonadBlockfrost m => TxHash -> m [TransactionMir]
 getTxMirs t = go (`getTxMirs_` t)
 
-getTxPoolUpdates_ :: Project -> TxHash -> BlockfrostClient [TransactionPoolUpdate]
+getTxPoolUpdates_ :: MonadBlockfrost m => Project -> TxHash -> m [TransactionPoolUpdate]
 getTxPoolUpdates_ = _txPoolUpdates . transactionsClient
 
 -- | Get transaction stake pool registration and update certificates
-getTxPoolUpdates :: TxHash -> BlockfrostClient [TransactionPoolUpdate]
+getTxPoolUpdates :: MonadBlockfrost m => TxHash -> m [TransactionPoolUpdate]
 getTxPoolUpdates t = go (`getTxPoolUpdates_` t)
 
-getTxPoolRetiring_ :: Project -> TxHash -> BlockfrostClient [TransactionPoolRetiring]
+getTxPoolRetiring_ :: MonadBlockfrost m => Project -> TxHash -> m [TransactionPoolRetiring]
 getTxPoolRetiring_ = _txPoolRetiring . transactionsClient
 
 -- | Get transaction stake pool retirement certificates
-getTxPoolRetiring :: TxHash -> BlockfrostClient [TransactionPoolRetiring]
+getTxPoolRetiring :: MonadBlockfrost m => TxHash -> m [TransactionPoolRetiring]
 getTxPoolRetiring t = go (`getTxPoolRetiring_` t)
 
-getTxMetadataJSON_ :: Project -> TxHash -> BlockfrostClient [TransactionMetaJSON]
+getTxMetadataJSON_ :: MonadBlockfrost m => Project -> TxHash -> m [TransactionMetaJSON]
 getTxMetadataJSON_ = _txMetadataJSON . transactionsClient
 
 -- | Get transaction metadata in JSON
-getTxMetadataJSON :: TxHash -> BlockfrostClient [TransactionMetaJSON]
+getTxMetadataJSON :: MonadBlockfrost m => TxHash -> m [TransactionMetaJSON]
 getTxMetadataJSON t = go (`getTxMetadataJSON_` t)
 
-getTxMetadataCBOR_ :: Project -> TxHash -> BlockfrostClient [TransactionMetaCBOR]
+getTxMetadataCBOR_ :: MonadBlockfrost m => Project -> TxHash -> m [TransactionMetaCBOR]
 getTxMetadataCBOR_ = _txMetadataCBOR . transactionsClient
 
 -- | Get transaction metadata in CBOR
-getTxMetadataCBOR :: TxHash -> BlockfrostClient [TransactionMetaCBOR]
+getTxMetadataCBOR :: MonadBlockfrost m => TxHash -> m [TransactionMetaCBOR]
 getTxMetadataCBOR t = go (`getTxMetadataCBOR_` t)
 
-submitTx_ :: Project -> CBORString -> BlockfrostClient TxHash
+submitTx_ :: MonadBlockfrost m => Project -> CBORString -> m TxHash
 submitTx_ = _txSubmit . cardanoClient
 
 -- | Submit an already serialized transaction to the network.
-submitTx :: CBORString -> BlockfrostClient TxHash
+submitTx :: MonadBlockfrost m => CBORString -> m TxHash
 submitTx txCbor = go (`submitTx_` txCbor)

--- a/blockfrost-client/src/Blockfrost/Client/IPFS.hs
+++ b/blockfrost-client/src/Blockfrost/Client/IPFS.hs
@@ -1,5 +1,6 @@
 -- | IPFS client functions
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE FlexibleContexts #-}
 
 module Blockfrost.Client.IPFS
   ( ipfsAdd
@@ -21,11 +22,11 @@ import qualified Data.Text
 import qualified System.Directory
 import qualified System.FilePath
 
-ipfsAdd_ :: Project -> (ByteString, Form) -> BlockfrostClient IPFSAdd
+ipfsAdd_ :: MonadBlockfrost m => Project -> (ByteString, Form) -> m IPFSAdd
 ipfsAdd_ = _add . ipfsClient
 
 -- | Add a file or directory to IPFS
-ipfsAdd :: FilePath -> BlockfrostClient IPFSAdd
+ipfsAdd :: (MonadError BlockfrostError m, MonadBlockfrost m) => FilePath -> m IPFSAdd
 ipfsAdd fp = do
   hasFile <- liftIO $ System.Directory.doesFileExist fp
   if hasFile
@@ -36,42 +37,42 @@ ipfsAdd fp = do
     else
       throwError (BlockfrostError "No such file")
 
-ipfsGateway_ :: Project -> Text -> BlockfrostClient IPFSData
+ipfsGateway_ :: MonadBlockfrost m => Project -> Text -> m IPFSData
 ipfsGateway_ = _gateway . ipfsClient
 
 -- | Fetch file via API
-ipfsGateway :: Text -> BlockfrostClient IPFSData
+ipfsGateway :: MonadBlockfrost m => Text -> m IPFSData
 ipfsGateway x = go (`ipfsGateway_` x)
 
-ipfsPin_ :: Project -> Text -> BlockfrostClient IPFSPinChange
+ipfsPin_ ::  MonadBlockfrost m => Project -> Text -> m IPFSPinChange
 ipfsPin_ = _pin . ipfsClient
 
 -- | Pin an object
-ipfsPin :: Text -> BlockfrostClient IPFSPinChange
+ipfsPin :: MonadBlockfrost m => Text -> m IPFSPinChange
 ipfsPin x = go (`ipfsPin_` x)
 
-ipfsListPins_ :: Project -> Paged -> SortOrder -> BlockfrostClient [IPFSPin]
+ipfsListPins_ :: MonadBlockfrost m => Project -> Paged -> SortOrder -> m [IPFSPin]
 ipfsListPins_ = _listPins . ipfsClient
 
 -- | List objects pinned to local storage
 -- Allows custom paging and ordering using @Paged@ and @SortOrder@.
-ipfsListPins' :: Paged -> SortOrder -> BlockfrostClient [IPFSPin]
+ipfsListPins' :: MonadBlockfrost m => Paged -> SortOrder -> m [IPFSPin]
 ipfsListPins' pg s = go (\p -> ipfsListPins_ p pg s)
 
 -- | List objects pinned to local storage
-ipfsListPins :: BlockfrostClient [IPFSPin]
+ipfsListPins :: MonadBlockfrost m => m [IPFSPin]
 ipfsListPins = ipfsListPins' def def
 
-ipfsGetPin_ :: Project -> Text -> BlockfrostClient IPFSPin
+ipfsGetPin_ :: MonadBlockfrost m => Project -> Text -> m IPFSPin
 ipfsGetPin_ = _getPin . ipfsClient
 
 -- | Get pinned object details
-ipfsGetPin :: Text -> BlockfrostClient IPFSPin
+ipfsGetPin :: MonadBlockfrost m => Text -> m IPFSPin
 ipfsGetPin x = go (`ipfsGetPin_` x)
 
-ipfsRemovePin_ :: Project -> Text -> BlockfrostClient IPFSPinChange
+ipfsRemovePin_ :: MonadBlockfrost m => Project -> Text -> m IPFSPinChange
 ipfsRemovePin_ = _removePin . ipfsClient
 
 -- | Remove pinned object from local storage
-ipfsRemovePin :: Text -> BlockfrostClient IPFSPinChange
+ipfsRemovePin :: MonadBlockfrost m => Text -> m IPFSPinChange
 ipfsRemovePin x = go (`ipfsRemovePin_` x)

--- a/blockfrost-client/src/Blockfrost/Client/NutLink.hs
+++ b/blockfrost-client/src/Blockfrost/Client/NutLink.hs
@@ -15,45 +15,45 @@ import Blockfrost.Client.Types
 import Blockfrost.Types
 import Data.Text (Text)
 
-nutlinkListAddress_ :: Project -> Address-> BlockfrostClient NutlinkAddress
+nutlinkListAddress_ :: MonadBlockfrost m => Project -> Address-> m NutlinkAddress
 nutlinkListAddress_ = _address . nutLinkClient
 
 -- | List metadata about specific address
-nutlinkListAddress :: Address -> BlockfrostClient NutlinkAddress
+nutlinkListAddress :: MonadBlockfrost m => Address -> m NutlinkAddress
 nutlinkListAddress a = go (`nutlinkListAddress_` a)
 
-nutlinkListAddressTickers_ :: Project -> Address -> Paged -> SortOrder -> BlockfrostClient [NutlinkAddressTicker]
+nutlinkListAddressTickers_ :: MonadBlockfrost m => Project -> Address -> Paged -> SortOrder -> m [NutlinkAddressTicker]
 nutlinkListAddressTickers_ = _listAddressTickers . nutLinkClient
 
 -- | List tickers for a specific metadata oracle
 -- Allows custom paging and ordering using @Paged@ and @SortOrder@.
-nutlinkListAddressTickers' :: Address -> Paged -> SortOrder -> BlockfrostClient [NutlinkAddressTicker]
+nutlinkListAddressTickers' :: MonadBlockfrost m => Address -> Paged -> SortOrder -> m [NutlinkAddressTicker]
 nutlinkListAddressTickers' a pg s = go (\p -> nutlinkListAddressTickers_ p a pg s)
 
 -- | List tickers for a specific metadata oracle
-nutlinkListAddressTickers :: Address -> BlockfrostClient [NutlinkAddressTicker]
+nutlinkListAddressTickers :: MonadBlockfrost m => Address -> m [NutlinkAddressTicker]
 nutlinkListAddressTickers a = nutlinkListAddressTickers' a def def
 
-nutlinkAddressTickers_ :: Project -> Address -> Text -> Paged -> SortOrder -> BlockfrostClient [NutlinkTicker]
+nutlinkAddressTickers_ :: MonadBlockfrost m => Project -> Address -> Text -> Paged -> SortOrder -> m [NutlinkTicker]
 nutlinkAddressTickers_ = _addressTickers . nutLinkClient
 
 -- | List of records of a specific ticker
 -- Allows custom paging and ordering using @Paged@ and @SortOrder@.
-nutlinkAddressTickers' :: Address -> Text -> Paged -> SortOrder -> BlockfrostClient [NutlinkTicker]
+nutlinkAddressTickers' :: MonadBlockfrost m => Address -> Text -> Paged -> SortOrder -> m [NutlinkTicker]
 nutlinkAddressTickers' a t pg s = go (\p -> nutlinkAddressTickers_ p a t pg s)
 
 -- | List of records of a specific ticker
-nutlinkAddressTickers :: Address -> Text -> BlockfrostClient [NutlinkTicker]
+nutlinkAddressTickers :: MonadBlockfrost m => Address -> Text -> m [NutlinkTicker]
 nutlinkAddressTickers a t = nutlinkAddressTickers' a t def def
 
-nutlinkTickers_ :: Project -> Text -> Paged -> SortOrder -> BlockfrostClient [(Address, NutlinkTicker)]
+nutlinkTickers_ :: MonadBlockfrost m => Project -> Text -> Paged -> SortOrder -> m [(Address, NutlinkTicker)]
 nutlinkTickers_ = _tickers . nutLinkClient
 
 -- | List of records of a specific ticker
 -- Allows custom paging and ordering using @Paged@ and @SortOrder@.
-nutlinkTickers' :: Text -> Paged -> SortOrder -> BlockfrostClient [(Address, NutlinkTicker)]
+nutlinkTickers' :: MonadBlockfrost m => Text -> Paged -> SortOrder -> m [(Address, NutlinkTicker)]
 nutlinkTickers' a pg s = go (\p -> nutlinkTickers_ p a pg s)
 
 -- | List of records of a specific ticker
-nutlinkTickers :: Text -> BlockfrostClient [(Address, NutlinkTicker)]
+nutlinkTickers :: MonadBlockfrost m => Text -> m [(Address, NutlinkTicker)]
 nutlinkTickers a = nutlinkTickers' a def def

--- a/blockfrost-client/src/Blockfrost/Client/Types.hs
+++ b/blockfrost-client/src/Blockfrost/Client/Types.hs
@@ -1,5 +1,7 @@
 -- | Client Types
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Blockfrost.Client.Types
   ( BlockfrostClient
@@ -20,6 +22,10 @@ module Blockfrost.Client.Types
   , fromServant
   , tryError
   , def
+  , BlockfrostClientT (..)
+  , MonadBlockfrost (..)
+  , runBlockfrostClientT
+  , newClientConfig
   ) where
 
 import Control.Monad.Except
@@ -34,36 +40,80 @@ import Blockfrost.API
 import Blockfrost.Client.Core
 
 type ClientConfig = (ClientEnv, Project)
-type BlockfrostClient =
-  ExceptT BlockfrostError
-    (ReaderT ClientConfig IO)
 
-apiClient :: BlockfrostAPI (AsClientT BlockfrostClient)
-apiClient = genericClientHoist nt
-  where nt :: ClientM a -> BlockfrostClient a
-        nt act = do
-          (env, _proj) <- ask
-          liftIO (runClientM act env)
-            >>= either (throwError . fromServantClientError) pure
+newtype BlockfrostClientT m a = BlockfrostClientT {
+  unBlockfrostClientT
+    :: ExceptT BlockfrostError
+        (ReaderT ClientConfig m) a
+  } deriving
+      ( Functor
+      , Applicative
+      , Monad
+      , MonadIO
+      , MonadReader ClientConfig
+      , MonadError BlockfrostError
+      )
 
-api0Client :: Project -> BlockfrostV0API (AsClientT BlockfrostClient)
+type BlockfrostClient = BlockfrostClientT IO
+
+class MonadIO m => MonadBlockfrost m where
+  liftBlockfrostClient :: ClientM a -> m a
+  getConf :: m ClientConfig
+
+instance MonadIO m => MonadBlockfrost (BlockfrostClientT m) where
+  liftBlockfrostClient act = BlockfrostClientT $ do
+    (env, _proj) <- ask
+    liftIO (runClientM act env)
+      >>= either (throwError . fromServantClientError) pure
+  getConf = BlockfrostClientT ask
+
+instance MonadBlockfrost ClientM where
+  liftBlockfrostClient = id
+  getConf = newClientConfig
+
+instance MonadBlockfrost IO where
+  liftBlockfrostClient act = getConf >>= \(env, _prj) -> runClientM act env >>= either (error . show) pure
+  getConf = newClientConfig
+
+apiClient :: MonadBlockfrost m => BlockfrostAPI (AsClientT m)
+apiClient = genericClientHoist liftBlockfrostClient
+
+api0Client :: MonadBlockfrost m => Project -> BlockfrostV0API (AsClientT m)
 api0Client = fromServant . _apiV0 apiClient
 
 -- ** Client runner
 
--- | Run @BlockfrostClient@ monad, using provided @Project@
-runBlockfrost :: Project
-  -> BlockfrostClient a
+-- | Run @BlockfrostClientT@ monad in @IO@, using provided @Project@
+runBlockfrost
+  :: Project
+  -> BlockfrostClientT IO a
   -> IO (Either BlockfrostError a)
-runBlockfrost proj act = do
-  env <- newEnvByProject proj
+runBlockfrost = runBlockfrostClientT
+
+-- | Run @BlockfrostClientT@, using provided @Project@
+runBlockfrostClientT
+  :: MonadIO m => Project
+  -> BlockfrostClientT m a
+  -> m (Either BlockfrostError a)
+runBlockfrostClientT proj act = do
+  env <- liftIO $ newEnvByProject proj
   flip runReaderT (env, proj)
-    $ runExceptT act
+    $ runExceptT $ unBlockfrostClientT act
+
+-- | Build default `ClientConfig` using BLOCKFROST_TOKEN_PATH environment variable
+newClientConfig
+  :: MonadIO m
+  => m ClientConfig
+newClientConfig = liftIO $ do
+  prj <- projectFromEnv
+  env <- newEnvByProject prj
+  pure (env, prj)
 
 -- | Helper
-go :: (Project -> BlockfrostClient a)
-  -> BlockfrostClient a
-go act = ask >>= act  . snd
+go :: MonadBlockfrost m
+   => (Project -> m a)
+   -> m a
+go act = getConf >>= act . snd
 
 -- Until mtl > 2.2.2
 -- https://github.com/haskell/mtl/pull/66
@@ -75,14 +125,14 @@ tryError action = (Right <$> action) `catchError` (pure . Left)
 
 -- ** Service clients
 
-commonClient :: Project -> CommonAPI (AsClientT BlockfrostClient)
+commonClient :: MonadBlockfrost m => Project -> CommonAPI (AsClientT m)
 commonClient = fromServant . _common . api0Client
 
-cardanoClient :: Project -> CardanoAPI (AsClientT BlockfrostClient)
+cardanoClient :: MonadBlockfrost m => Project -> CardanoAPI (AsClientT m)
 cardanoClient = fromServant . _cardano . api0Client
 
-ipfsClient :: Project -> IPFSAPI (AsClientT BlockfrostClient)
+ipfsClient :: MonadBlockfrost m => Project -> IPFSAPI (AsClientT m)
 ipfsClient = fromServant . _ipfs . api0Client
 
-nutLinkClient :: Project -> NutLinkAPI (AsClientT BlockfrostClient)
+nutLinkClient :: MonadBlockfrost m => Project -> NutLinkAPI (AsClientT m)
 nutLinkClient = fromServant . _nutLink . api0Client


### PR DESCRIPTION
Allows using custom base monad which needs to implement
`MonadBlockfrost` class. `BlockfrostClient` is preserved
as a default monad.

Closes #10.