### PR TITLE
Upgrade servant to >= 0.19

### DIFF
--- a/blockfrost-api/blockfrost-api.cabal
+++ b/blockfrost-api/blockfrost-api.cabal
@@ -128,7 +128,7 @@ library
                       , deriving-aeson
                       , lens
                       , template-haskell
-                      , servant                  ^>= 0.18
+                      , servant                  >= 0.19
                       , servant-docs
                       , servant-multipart-api
                       , safe-money

--- a/blockfrost-client-core/blockfrost-client-core.cabal
+++ b/blockfrost-client-core/blockfrost-client-core.cabal
@@ -53,7 +53,7 @@ library
                       , http-client
                       , http-client-tls
                       , http-types
-                      , servant                  ^>= 0.18
+                      , servant                  >= 0.19
                       , servant-client
                       , servant-client-core
                       , servant-multipart-api

--- a/blockfrost-client/blockfrost-client.cabal
+++ b/blockfrost-client/blockfrost-client.cabal
@@ -72,7 +72,7 @@ library
                       , filepath
                       , text
                       , mtl
-                      , servant                  ^>= 0.18
+                      , servant                  >= 0.19
                       , servant-client
                       , servant-client-core
 


### PR DESCRIPTION
This PR upgrades servant to >= 0.19.

Reason: servant <= 0.18 is not compatible with aeson >= 2.0.