### PR TITLE
Leave out pool_ids when calling getEpochStakeByPool. Fixes #22

### DIFF
--- a/blockfrost-api/src/Blockfrost/API/Cardano/Epochs.hs
+++ b/blockfrost-api/src/Blockfrost/API/Cardano/Epochs.hs
@@ -67,7 +67,7 @@ data EpochsAPI route =
         :> "stakes"
         :> Capture "pool_id" PoolId
         :> Pagination
-        :> Get '[JSON] [StakeDistribution]
+        :> Get '[JSON] [PoolStakeDistribution]
      , _getEpochBlocks
         :: route
         :- Summary "Block distribution"

--- a/blockfrost-client/src/Blockfrost/Client/Cardano/Epochs.hs
+++ b/blockfrost-client/src/Blockfrost/Client/Cardano/Epochs.hs
@@ -84,16 +84,16 @@ getEpochStake' e pg = go (\p -> getEpochStake_ p e pg)
 getEpochStake :: MonadBlockfrost m => Epoch -> m [StakeDistribution]
 getEpochStake e = getEpochStake' e def
 
-getEpochStakeByPool_ :: MonadBlockfrost m => Project -> Epoch -> PoolId -> Paged -> m [StakeDistribution]
+getEpochStakeByPool_ :: MonadBlockfrost m => Project -> Epoch -> PoolId -> Paged -> m [PoolStakeDistribution]
 getEpochStakeByPool_ = _getEpochStakeByPool . epochsClient
 
 -- | Return the active stake distribution for the epoch specified by stake pool.
 -- Allows custom paging using @Paged@.
-getEpochStakeByPool' :: MonadBlockfrost m => Epoch -> PoolId -> Paged -> m [StakeDistribution]
+getEpochStakeByPool' :: MonadBlockfrost m => Epoch -> PoolId -> Paged -> m [PoolStakeDistribution]
 getEpochStakeByPool' e i pg = go (\p -> getEpochStakeByPool_ p e i pg)
 
 -- | Return the active stake distribution for the epoch specified by stake pool.
-getEpochStakeByPool :: MonadBlockfrost m => Epoch -> PoolId -> m [StakeDistribution]
+getEpochStakeByPool :: MonadBlockfrost m => Epoch -> PoolId -> m [PoolStakeDistribution]
 getEpochStakeByPool e i = getEpochStakeByPool' e i def
 
 getEpochBlocks_ :: MonadBlockfrost m => Project -> Epoch -> Paged -> SortOrder -> m [BlockHash]


### PR DESCRIPTION
In other words, return a `PoolStakeDistribution` rather than a
`StakeDistribution`. This makes this repo's api match the Blockfrost endpoint's observed actual behavior.