### PR TITLE
client-core: fix order of results returned by `allPages`

### DIFF
--- a/blockfrost-client-core/src/Blockfrost/Client/Pagination.hs
+++ b/blockfrost-client-core/src/Blockfrost/Client/Pagination.hs
@@ -41,7 +41,7 @@ allPages act = do
           xs | length xs < maxPageSize -> pure xs
           xs -> do
             next <- fetch (nextPage page')
-            pure $ next ++ xs
+            pure $ xs ++ next
   fetch def
 
 instance HasClient m subApi => HasClient m (Pagination :> subApi) where


### PR DESCRIPTION
Closes #26.