### PR TITLE
Introduce `ScriptHashList` newtype

### DIFF
--- a/blockfrost-api/CHANGELOG.md
+++ b/blockfrost-api/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version [0.7.0.0](https://github.com/blockfrost/blockfrost-haskell/compare/v0.6.0.0...v0.7.0.0) (2022-10-11)
+
+* Changes
+  * Added `ScriptHashList` newtype instead of overlapping instance for `[ScriptHash]` which is used
+    as a result of `_listScripts` in `ScriptsAPI`
+
 # Version [0.6.0.0](https://github.com/blockfrost/blockfrost-haskell/compare/v0.5.0.0...v0.6.0.0) (2022-08-31)
 
 * Additions

--- a/blockfrost-api/blockfrost-api.cabal
+++ b/blockfrost-api/blockfrost-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                blockfrost-api
-version:             0.6.0.0
+version:             0.7.0.0
 synopsis:            API definitions for blockfrost.io
 description:         Core types and Servant API description
 homepage:            https://github.com/blockfrost/blockfrost-haskell

--- a/blockfrost-api/src/Blockfrost/API/Cardano/Scripts.hs
+++ b/blockfrost-api/src/Blockfrost/API/Cardano/Scripts.hs
@@ -22,7 +22,7 @@ data ScriptsAPI route =
         :> Description "List of scripts."
         :> Pagination
         :> Sorting
-        :> Get '[JSON] [ScriptHash]
+        :> Get '[JSON] ScriptHashList
     , _getScript
         :: route
         :- Summary "Specific scripts"

--- a/blockfrost-api/test/Cardano/Scripts.hs
+++ b/blockfrost-api/test/Cardano/Scripts.hs
@@ -66,8 +66,8 @@ scriptListSample = [r|
 ]
 |]
 
-scriptListExpected :: [ScriptHash]
-scriptListExpected =
+scriptListExpected :: ScriptHashList
+scriptListExpected = ScriptHashList
   [ "67f33146617a5e61936081db3b2117cbf59bd2123748f58ac9678656"
   , "e1457a0c47dfb7a2f6b8fbb059bdceab163c05d34f195b87b9f2b30e"
   , "a6e63c0ff05c96943d1cc30bf53112ffff0f34b45986021ca058ec54"

--- a/blockfrost-client/CHANGELOG.md
+++ b/blockfrost-client/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version [0.7.0.0](https://github.com/blockfrost/blockfrost-haskell/compare/v0.6.0.0...v0.7.0.0) (2022-10-11)
+
+* Changes
+  * `listScript` and `listScripts'` now return `ScriptHashList` newtype
+    instead of `[ScriptHash]` due to overlapping instance conflicts
+
 # Version [0.6.0.0](https://github.com/blockfrost/blockfrost-haskell/compare/v0.5.0.0...v0.6.0.0) (2022-08-31)
 
 * Additions

--- a/blockfrost-client/blockfrost-client.cabal
+++ b/blockfrost-client/blockfrost-client.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                blockfrost-client
-version:             0.6.0.0
+version:             0.7.0.0
 synopsis:            blockfrost.io basic client
 description:         Simple Blockfrost clients for use with transformers or mtl
 homepage:            https://github.com/blockfrost/blockfrost-haskell
@@ -64,7 +64,7 @@ library
                       , Blockfrost.Client.IPFS
                       , Blockfrost.Client.NutLink
    build-depends:       base                     >= 4.7 && < 5
-                      , blockfrost-api           ^>= 0.6
+                      , blockfrost-api           ^>= 0.7
                       , blockfrost-client-core   ^>= 0.6
                       , bytestring
                       , directory

--- a/blockfrost-client/src/Blockfrost/Client/Cardano/Scripts.hs
+++ b/blockfrost-client/src/Blockfrost/Client/Cardano/Scripts.hs
@@ -19,12 +19,12 @@ import Blockfrost.Types
 scriptsClient :: MonadBlockfrost m => Project -> ScriptsAPI (AsClientT m)
 scriptsClient = fromServant . _scripts . cardanoClient
 
-listScripts_ :: MonadBlockfrost m => Project -> Paged -> SortOrder -> m [ScriptHash]
+listScripts_ :: MonadBlockfrost m => Project -> Paged -> SortOrder -> m ScriptHashList
 listScripts_ = _listScripts . scriptsClient
 
 -- | List scripts
 -- Allows custom paging and ordering using 'Paged' and 'SortOrder'.
-listScripts' :: MonadBlockfrost m => Paged -> SortOrder -> m [ScriptHash]
+listScripts' :: MonadBlockfrost m => Paged -> SortOrder -> m ScriptHashList
 listScripts' pg s = go (\p -> listScripts_ p pg s)
 
 -- | List scripts
@@ -32,7 +32,7 @@ listScripts' pg s = go (\p -> listScripts_ p pg s)
 -- Queries 100 entries. To query all entries use 'Blockfrost.Client.Core.allPages'
 -- with principled variant of this function (suffixed with @'@)
 -- that accepts 'Paged' argument.
-listScripts :: MonadBlockfrost m => m [ScriptHash]
+listScripts :: MonadBlockfrost m => m ScriptHashList
 listScripts = listScripts' def def
 
 getScript_ :: MonadBlockfrost m => Project -> ScriptHash -> m Script


### PR DESCRIPTION
to avoid overlapping `aeson` instance for list (https://github.com/blockfrost/blockfrost-haskell/issues/29).