### PR TITLE
Add support for `/network/eras` endpoint

### DIFF
--- a/blockfrost-api/src/Blockfrost/API/Cardano/Network.hs
+++ b/blockfrost-api/src/Blockfrost/API/Cardano/Network.hs
@@ -18,4 +18,10 @@ data NetworkAPI route =
         :- Summary "Network information"
         :> Description "Return detailed network information."
         :> Get '[JSON] Network
+    , _networkEras
+        :: route
+        :- Summary "Query summary of blockchain eras"
+        :> Description "Returns start and end of each era along with parameters that can vary between hard forks."
+        :> "eras"
+        :> Get '[JSON] [NetworkEraSummary]
     } deriving (Generic)

--- a/blockfrost-api/src/Blockfrost/Types/Shared/Epoch.hs
+++ b/blockfrost-api/src/Blockfrost/Types/Shared/Epoch.hs
@@ -1,9 +1,8 @@
 -- | Epoch
-
-module Blockfrost.Types.Shared.Epoch
-  where
+module Blockfrost.Types.Shared.Epoch where
 
 import Data.Aeson (FromJSON, ToJSON)
+import Data.Word (Word64)
 import GHC.Generics
 import Servant.API (Capture, FromHttpApiData (..), ToHttpApiData (..))
 import Servant.Docs (DocCapture (..), ToCapture (..), ToSample (..), samples)
@@ -19,4 +18,17 @@ instance ToCapture (Capture "epoch_number" Epoch) where
   toCapture _ = DocCapture "epoch_number" "Epoch for specific epoch slot."
 
 instance ToSample Epoch where
-    toSamples = pure $ samples [425, 500, 1200]
+  toSamples = pure $ samples [425, 500, 1200]
+
+newtype EpochLength = EpochLength Word64
+  deriving stock (Eq, Ord, Show, Generic)
+  deriving newtype (Num, Enum, Real, Integral, FromHttpApiData, ToHttpApiData, FromJSON, ToJSON)
+
+unEpochLength :: EpochLength -> Word64
+unEpochLength (EpochLength u) = u
+
+instance ToCapture (Capture "epoch_length" EpochLength) where
+  toCapture _ = DocCapture "epoch_length" "Epoch size in a specific Cardano era."
+
+instance ToSample EpochLength where
+  toSamples = pure $ samples [21600, 86400, 432000]

--- a/blockfrost-client/src/Blockfrost/Client.hs
+++ b/blockfrost-client/src/Blockfrost/Client.hs
@@ -97,6 +97,7 @@ module Blockfrost.Client
   , getTxMetadataByLabelCBOR'
     -- Cardano - Network
   , getNetworkInfo
+  , getNetworkEras
     -- Cardano - Pools
   , listPools
   , listPools'

--- a/blockfrost-client/src/Blockfrost/Client/Cardano/Network.hs
+++ b/blockfrost-client/src/Blockfrost/Client/Cardano/Network.hs
@@ -2,6 +2,7 @@
 
 module Blockfrost.Client.Cardano.Network
   ( getNetworkInfo
+  , getNetworkEras
   ) where
 
 import Blockfrost.API
@@ -18,3 +19,10 @@ getNetworkInfo_ = _networkInfo . networkClient
 -- | Get detailed network information.
 getNetworkInfo :: MonadBlockfrost m => m Network
 getNetworkInfo = go getNetworkInfo_
+
+getNetworkEras_ :: MonadBlockfrost m => Project -> m [NetworkEraSummary]
+getNetworkEras_ = _networkEras . networkClient
+
+-- | Get summarized information on each era in the network, including start, end, and variable era parameters.
+getNetworkEras :: MonadBlockfrost m => m [NetworkEraSummary]
+getNetworkEras = go getNetworkEras_


### PR DESCRIPTION
I noticed [era summaries](https://docs.blockfrost.io/#tag/Cardano-Network/paths/~1network~1eras/get) was missing.