### PR TITLE
Bump `api` Version for `client`

### DIFF
--- a/blockfrost-client/blockfrost-client.cabal
+++ b/blockfrost-client/blockfrost-client.cabal
@@ -66,7 +66,7 @@ library
                       , Blockfrost.Client.IPFS
                       , Blockfrost.Client.NutLink
    build-depends:       base                     >= 4.7 && < 5
-                      , blockfrost-api           >= 0.9
+                      , blockfrost-api           >= 0.10
                       , blockfrost-client-core   ^>= 0.6
                       , bytestring
                       , directory


### PR DESCRIPTION
Thank you @sorki for the swift patch. The issue with `Blockfrost.Client.txEvaluate` still seems to be persisting. I believe increasing the `blockfrost-api` dependency version should fix it.