### PR TITLE
feat(#58): add conway related protocol parameters

### DIFF
--- a/blockfrost-api/src/Blockfrost/Types/Cardano/Epochs.hs
+++ b/blockfrost-api/src/Blockfrost/Types/Cardano/Epochs.hs
@@ -88,10 +88,32 @@ data ProtocolParams = ProtocolParams
   , _protocolParamsMaxCollateralInputs    :: Integer -- ^ The maximum number of collateral inputs allowed in a transaction
   , _protocolParamsCoinsPerUtxoSize       :: Lovelaces -- ^ The cost per UTxO size. Cost per UTxO *word* for Alozno. Cost per UTxO *byte* for Babbage and later
   , _protocolParamsCoinsPerUtxoWord       :: Lovelaces -- ^ The cost per UTxO word (DEPRECATED)
+  , _protocolParamsPvtMotionNoConfidence :: Maybe Rational
+  , _protocolParamsPvtCommitteeNormal :: Maybe Rational
+  , _protocolParamsPvtCommitteeNoConfidence :: Maybe Rational
+  , _protocolParamsPvtHardForkInitiation :: Maybe Rational
+  , _protocolParamsPvtppSecurityGroup :: Maybe Rational
+  , _protocolParamsDvtMotionNoConfidence :: Maybe Rational
+  , _protocolParamsDvtCommitteeNormal :: Maybe Rational
+  , _protocolParamsDvtCommitteeNoConfidence :: Maybe Rational
+  , _protocolParamsDvtUpdateToConstitution :: Maybe Rational
+  , _protocolParamsDvtHardForkInitiation :: Maybe Rational
+  , _protocolParamsDvtPPNetworkGroup :: Maybe Rational
+  , _protocolParamsDvtPPEconomicGroup :: Maybe Rational
+  , _protocolParamsDvtPPTechnicalGroup :: Maybe Rational
+  , _protocolParamsDvtPPGovGroup :: Maybe Rational
+  , _protocolParamsDvtTreasuryWithdrawal :: Maybe Rational
+  , _protocolParamsCommitteeMinSize :: Maybe Quantity
+  , _protocolParamsCommitteeMaxTermLength :: Maybe Quantity
+  , _protocolParamsGovActionLifetime :: Maybe Quantity
+  , _protocolParamsGovActionDeposit :: Maybe Lovelaces
+  , _protocolParamsDrepDeposit :: Maybe Lovelaces
+  , _protocolParamsDrepActivity :: Maybe Quantity
+  , _protocolParamsMinFeeRefScriptCostPerByte :: Maybe Integer
   }
   deriving stock (Show, Eq, Generic)
   deriving (FromJSON, ToJSON)
-  via CustomJSON '[FieldLabelModifier '[StripPrefix "_protocolParams", CamelToSnake]] ProtocolParams
+  via CustomJSON '[FieldLabelModifier '[StripPrefix "_protocolParams", CamelToSnake, Rename "dvt_pp_network_group" "dvt_p_p_network_group", Rename "dvt_pp_economic_group" "dvt_p_p_economic_group", Rename "dvt_pp_technical_group" "dvt_p_p_technical_group", Rename "dvt_pp_gov_group" "dvt_p_p_gov_group"]] ProtocolParams
 
 instance ToSample ProtocolParams where
   toSamples = pure $ singleSample
@@ -128,6 +150,28 @@ instance ToSample ProtocolParams where
       , _protocolParamsMaxCollateralInputs = 3
       , _protocolParamsCoinsPerUtxoSize = 34482
       , _protocolParamsCoinsPerUtxoWord = 34482
+      , _protocolParamsPvtMotionNoConfidence = Just 0.51
+      , _protocolParamsPvtCommitteeNormal = Just 0.51
+      , _protocolParamsPvtCommitteeNoConfidence = Just 0.51
+      , _protocolParamsPvtHardForkInitiation = Just 0.51
+      , _protocolParamsPvtppSecurityGroup = Just 0.51
+      , _protocolParamsDvtMotionNoConfidence = Just 0.67
+      , _protocolParamsDvtCommitteeNormal = Just 0.67
+      , _protocolParamsDvtCommitteeNoConfidence = Just 0.6
+      , _protocolParamsDvtUpdateToConstitution = Just 0.75
+      , _protocolParamsDvtHardForkInitiation = Just 0.6
+      , _protocolParamsDvtPPNetworkGroup = Just 0.67
+      , _protocolParamsDvtPPEconomicGroup = Just 0.67
+      , _protocolParamsDvtPPTechnicalGroup = Just 0.67
+      , _protocolParamsDvtPPGovGroup = Just 0.75
+      , _protocolParamsDvtTreasuryWithdrawal = Just 0.67
+      , _protocolParamsCommitteeMinSize = Just 7
+      , _protocolParamsCommitteeMaxTermLength = Just 146
+      , _protocolParamsGovActionLifetime = Just 6
+      , _protocolParamsGovActionDeposit = Just 100000000000
+      , _protocolParamsDrepDeposit = Just 500000000
+      , _protocolParamsDrepActivity = Just 20
+      , _protocolParamsMinFeeRefScriptCostPerByte = Just 15
       }
 
 newtype CostModels = CostModels { unCostModels :: Map ScriptType (Map Text Integer) }

--- a/blockfrost-api/src/Blockfrost/Types/Cardano/Epochs.hs
+++ b/blockfrost-api/src/Blockfrost/Types/Cardano/Epochs.hs
@@ -109,7 +109,7 @@ data ProtocolParams = ProtocolParams
   , _protocolParamsGovActionDeposit :: Maybe Lovelaces
   , _protocolParamsDrepDeposit :: Maybe Lovelaces
   , _protocolParamsDrepActivity :: Maybe Quantity
-  , _protocolParamsMinFeeRefScriptCostPerByte :: Maybe Integer
+  , _protocolParamsMinFeeRefScriptCostPerByte :: Maybe Rational
   }
   deriving stock (Show, Eq, Generic)
   deriving (FromJSON, ToJSON)

--- a/blockfrost-api/test/Cardano/Epochs.hs
+++ b/blockfrost-api/test/Cardano/Epochs.hs
@@ -100,6 +100,20 @@ protocolParamsSample = [r|
         "addInteger-cpu-arguments-slope": 0
       }
     },
+    "cost_models_raw": {
+      "PlutusV1": [
+        197209,
+        0
+      ],
+      "PlutusV2": [
+        197209,
+        0
+      ],
+      "PlutusV3": [
+        197209,
+        0
+      ]
+    },
     "price_mem": 0.0577,
     "price_step": 0.0000721,
     "max_tx_ex_mem": "10000000",
@@ -171,6 +185,25 @@ protocolParamsExpected =
         , Data.Map.fromList
           [ ("addInteger-cpu-arguments-intercept", 197209)
           , ("addInteger-cpu-arguments-slope", 0)
+          ]
+        )
+      ]
+    , _protocolParamsCostModelsRaw =
+        CostModelsRaw
+      $ Data.Map.fromList
+      [ ( PlutusV1
+        , [ 197209
+          , 0
+          ]
+        )
+      , (PlutusV2
+        , [ 197209
+          , 0
+          ]
+        )
+      , (PlutusV3
+        , [ 197209
+          , 0
           ]
         )
       ]

--- a/blockfrost-api/test/Cardano/Epochs.hs
+++ b/blockfrost-api/test/Cardano/Epochs.hs
@@ -110,7 +110,29 @@ protocolParamsSample = [r|
     "collateral_percent": 150,
     "max_collateral_inputs": 3,
     "coins_per_utxo_size": "34482",
-    "coins_per_utxo_word": "34482"
+    "coins_per_utxo_word": "34482",
+    "pvt_motion_no_confidence": 0.51,
+    "pvt_committee_normal": 0.51,
+    "pvt_committee_no_confidence": 0.51,
+    "pvt_hard_fork_initiation": 0.51,
+    "dvt_motion_no_confidence": 0.67,
+    "dvt_committee_normal": 0.67,
+    "dvt_committee_no_confidence": 0.6,
+    "dvt_update_to_constitution": 0.75,
+    "dvt_hard_fork_initiation": 0.6,
+    "dvt_p_p_network_group": 0.67,
+    "dvt_p_p_economic_group": 0.67,
+    "dvt_p_p_technical_group": 0.67,
+    "dvt_p_p_gov_group": 0.75,
+    "dvt_treasury_withdrawal": 0.67,
+    "committee_min_size": "7",
+    "committee_max_term_length": "146",
+    "gov_action_lifetime": "6",
+    "gov_action_deposit": "100000000000",
+    "drep_deposit": "500000000",
+    "drep_activity": "20",
+    "pvtpp_security_group": 0.51,
+    "min_fee_ref_script_cost_per_byte": 15
 }
 |]
 
@@ -164,6 +186,28 @@ protocolParamsExpected =
     , _protocolParamsCoinsPerUtxoSize = 34482
     -- deprecated
     , _protocolParamsCoinsPerUtxoWord = 34482
+    , _protocolParamsPvtMotionNoConfidence = Just 0.51
+    , _protocolParamsPvtCommitteeNormal = Just 0.51
+    , _protocolParamsPvtCommitteeNoConfidence = Just 0.51
+    , _protocolParamsPvtHardForkInitiation = Just 0.51
+    , _protocolParamsPvtppSecurityGroup = Just 0.51
+    , _protocolParamsDvtMotionNoConfidence = Just 0.67
+    , _protocolParamsDvtCommitteeNormal = Just 0.67
+    , _protocolParamsDvtCommitteeNoConfidence = Just 0.6
+    , _protocolParamsDvtUpdateToConstitution = Just 0.75
+    , _protocolParamsDvtHardForkInitiation = Just 0.6
+    , _protocolParamsDvtPPNetworkGroup = Just 0.67
+    , _protocolParamsDvtPPEconomicGroup = Just 0.67
+    , _protocolParamsDvtPPTechnicalGroup = Just 0.67
+    , _protocolParamsDvtPPGovGroup = Just 0.75
+    , _protocolParamsDvtTreasuryWithdrawal = Just 0.67
+    , _protocolParamsCommitteeMinSize = Just 7
+    , _protocolParamsCommitteeMaxTermLength = Just 146
+    , _protocolParamsGovActionLifetime = Just 6
+    , _protocolParamsGovActionDeposit = Just 100000000000
+    , _protocolParamsDrepDeposit = Just 500000000
+    , _protocolParamsDrepActivity = Just 20
+    , _protocolParamsMinFeeRefScriptCostPerByte = Just 15
     }
 
 stakeDistributionSample = [r|


### PR DESCRIPTION
Closes #58, closes #60.

For reference, here is what Blockfrost returned for latest epoch:

```
{
  "epoch": 507,
  "min_fee_a": 44,
  "min_fee_b": 155381,
  "max_block_size": 90112,
  "max_tx_size": 16384,
  "max_block_header_size": 1100,
  "key_deposit": "2000000",
  "pool_deposit": "500000000",
  "e_max": 18,
  "n_opt": 500,
  "a0": 0.3,
  "rho": 0.003,
  "tau": 0.2,
  "decentralisation_param": 0,
  "extra_entropy": null,
  "protocol_major_ver": 9,
  "protocol_minor_ver": 0,
  "min_utxo": "4310",
  "min_pool_cost": "170000000",
  "nonce": "1556b02efe433eefb439572d1794865e6e116de46d16dbfe2ce037bbbbc66f48",
  "cost_models": {
    "PlutusV1": {
      "addInteger-cpu-arguments-intercept": 100788,
      "addInteger-cpu-arguments-slope": 420,
      "addInteger-memory-arguments-intercept": 1,
      "addInteger-memory-arguments-slope": 1,
      "appendByteString-cpu-arguments-intercept": 1000,
      "appendByteString-cpu-arguments-slope": 173,
      "appendByteString-memory-arguments-intercept": 0,
      "appendByteString-memory-arguments-slope": 1,
      "appendString-cpu-arguments-intercept": 1000,
      "appendString-cpu-arguments-slope": 59957,
      "appendString-memory-arguments-intercept": 4,
      "appendString-memory-arguments-slope": 1,
      "bData-cpu-arguments": 11183,
      "bData-memory-arguments": 32,
      "blake2b_256-cpu-arguments-intercept": 201305,
      "blake2b_256-cpu-arguments-slope": 8356,
      "blake2b_256-memory-arguments": 4,
      "cekApplyCost-exBudgetCPU": 16000,
      "cekApplyCost-exBudgetMemory": 100,
      "cekBuiltinCost-exBudgetCPU": 16000,
      "cekBuiltinCost-exBudgetMemory": 100,
      "cekConstCost-exBudgetCPU": 16000,
      "cekConstCost-exBudgetMemory": 100,
      "cekDelayCost-exBudgetCPU": 16000,
      "cekDelayCost-exBudgetMemory": 100,
      "cekForceCost-exBudgetCPU": 16000,
      "cekForceCost-exBudgetMemory": 100,
      "cekLamCost-exBudgetCPU": 16000,
      "cekLamCost-exBudgetMemory": 100,
      "cekStartupCost-exBudgetCPU": 100,
      "cekStartupCost-exBudgetMemory": 100,
      "cekVarCost-exBudgetCPU": 16000,
      "cekVarCost-exBudgetMemory": 100,
      "chooseData-cpu-arguments": 94375,
      "chooseData-memory-arguments": 32,
      "chooseList-cpu-arguments": 132994,
      "chooseList-memory-arguments": 32,
      "chooseUnit-cpu-arguments": 61462,
      "chooseUnit-memory-arguments": 4,
      "consByteString-cpu-arguments-intercept": 72010,
      "consByteString-cpu-arguments-slope": 178,
      "consByteString-memory-arguments-intercept": 0,
      "consByteString-memory-arguments-slope": 1,
      "constrData-cpu-arguments": 22151,
      "constrData-memory-arguments": 32,
      "decodeUtf8-cpu-arguments-intercept": 91189,
      "decodeUtf8-cpu-arguments-slope": 769,
      "decodeUtf8-memory-arguments-intercept": 4,
      "decodeUtf8-memory-arguments-slope": 2,
      "divideInteger-cpu-arguments-constant": 85848,
      "divideInteger-cpu-arguments-model-arguments-intercept": 228465,
      "divideInteger-cpu-arguments-model-arguments-slope": 122,
      "divideInteger-memory-arguments-intercept": 0,
      "divideInteger-memory-arguments-minimum": 1,
      "divideInteger-memory-arguments-slope": 1,
      "encodeUtf8-cpu-arguments-intercept": 1000,
      "encodeUtf8-cpu-arguments-slope": 42921,
      "encodeUtf8-memory-arguments-intercept": 4,
      "encodeUtf8-memory-arguments-slope": 2,
      "equalsByteString-cpu-arguments-constant": 24548,
      "equalsByteString-cpu-arguments-intercept": 29498,
      "equalsByteString-cpu-arguments-slope": 38,
      "equalsByteString-memory-arguments": 1,
      "equalsData-cpu-arguments-intercept": 898148,
      "equalsData-cpu-arguments-slope": 27279,
      "equalsData-memory-arguments": 1,
      "equalsInteger-cpu-arguments-intercept": 51775,
      "equalsInteger-cpu-arguments-slope": 558,
      "equalsInteger-memory-arguments": 1,
      "equalsString-cpu-arguments-constant": 39184,
      "equalsString-cpu-arguments-intercept": 1000,
      "equalsString-cpu-arguments-slope": 60594,
      "equalsString-memory-arguments": 1,
      "fstPair-cpu-arguments": 141895,
      "fstPair-memory-arguments": 32,
      "headList-cpu-arguments": 83150,
      "headList-memory-arguments": 32,
      "iData-cpu-arguments": 15299,
      "iData-memory-arguments": 32,
      "ifThenElse-cpu-arguments": 76049,
      "ifThenElse-memory-arguments": 1,
      "indexByteString-cpu-arguments": 13169,
      "indexByteString-memory-arguments": 4,
      "lengthOfByteString-cpu-arguments": 22100,
      "lengthOfByteString-memory-arguments": 10,
      "lessThanByteString-cpu-arguments-intercept": 28999,
      "lessThanByteString-cpu-arguments-slope": 74,
      "lessThanByteString-memory-arguments": 1,
      "lessThanEqualsByteString-cpu-arguments-intercept": 28999,
      "lessThanEqualsByteString-cpu-arguments-slope": 74,
      "lessThanEqualsByteString-memory-arguments": 1,
      "lessThanEqualsInteger-cpu-arguments-intercept": 43285,
      "lessThanEqualsInteger-cpu-arguments-slope": 552,
      "lessThanEqualsInteger-memory-arguments": 1,
      "lessThanInteger-cpu-arguments-intercept": 44749,
      "lessThanInteger-cpu-arguments-slope": 541,
      "lessThanInteger-memory-arguments": 1,
      "listData-cpu-arguments": 33852,
      "listData-memory-arguments": 32,
      "mapData-cpu-arguments": 68246,
      "mapData-memory-arguments": 32,
      "mkCons-cpu-arguments": 72362,
      "mkCons-memory-arguments": 32,
      "mkNilData-cpu-arguments": 7243,
      "mkNilData-memory-arguments": 32,
      "mkNilPairData-cpu-arguments": 7391,
      "mkNilPairData-memory-arguments": 32,
      "mkPairData-cpu-arguments": 11546,
      "mkPairData-memory-arguments": 32,
      "modInteger-cpu-arguments-constant": 85848,
      "modInteger-cpu-arguments-model-arguments-intercept": 228465,
      "modInteger-cpu-arguments-model-arguments-slope": 122,
      "modInteger-memory-arguments-intercept": 0,
      "modInteger-memory-arguments-minimum": 1,
      "modInteger-memory-arguments-slope": 1,
      "multiplyInteger-cpu-arguments-intercept": 90434,
      "multiplyInteger-cpu-arguments-slope": 519,
      "multiplyInteger-memory-arguments-intercept": 0,
      "multiplyInteger-memory-arguments-slope": 1,
      "nullList-cpu-arguments": 74433,
      "nullList-memory-arguments": 32,
      "quotientInteger-cpu-arguments-constant": 85848,
      "quotientInteger-cpu-arguments-model-arguments-intercept": 228465,
      "quotientInteger-cpu-arguments-model-arguments-slope": 122,
      "quotientInteger-memory-arguments-intercept": 0,
      "quotientInteger-memory-arguments-minimum": 1,
      "quotientInteger-memory-arguments-slope": 1,
      "remainderInteger-cpu-arguments-constant": 85848,
      "remainderInteger-cpu-arguments-model-arguments-intercept": 228465,
      "remainderInteger-cpu-arguments-model-arguments-slope": 122,
      "remainderInteger-memory-arguments-intercept": 0,
      "remainderInteger-memory-arguments-minimum": 1,
      "remainderInteger-memory-arguments-slope": 1,
      "sha2_256-cpu-arguments-intercept": 270652,
      "sha2_256-cpu-arguments-slope": 22588,
      "sha2_256-memory-arguments": 4,
      "sha3_256-cpu-arguments-intercept": 1457325,
      "sha3_256-cpu-arguments-slope": 64566,
      "sha3_256-memory-arguments": 4,
      "sliceByteString-cpu-arguments-intercept": 20467,
      "sliceByteString-cpu-arguments-slope": 1,
      "sliceByteString-memory-arguments-intercept": 4,
      "sliceByteString-memory-arguments-slope": 0,
      "sndPair-cpu-arguments": 141992,
      "sndPair-memory-arguments": 32,
      "subtractInteger-cpu-arguments-intercept": 100788,
      "subtractInteger-cpu-arguments-slope": 420,
      "subtractInteger-memory-arguments-intercept": 1,
      "subtractInteger-memory-arguments-slope": 1,
      "tailList-cpu-arguments": 81663,
      "tailList-memory-arguments": 32,
      "trace-cpu-arguments": 59498,
      "trace-memory-arguments": 32,
      "unBData-cpu-arguments": 20142,
      "unBData-memory-arguments": 32,
      "unConstrData-cpu-arguments": 24588,
      "unConstrData-memory-arguments": 32,
      "unIData-cpu-arguments": 20744,
      "unIData-memory-arguments": 32,
      "unListData-cpu-arguments": 25933,
      "unListData-memory-arguments": 32,
      "unMapData-cpu-arguments": 24623,
      "unMapData-memory-arguments": 32,
      "verifyEd25519Signature-cpu-arguments-intercept": 53384111,
      "verifyEd25519Signature-cpu-arguments-slope": 14333,
      "verifyEd25519Signature-memory-arguments": 10
    },
    "PlutusV2": {
      "addInteger-cpu-arguments-intercept": 100788,
      "addInteger-cpu-arguments-slope": 420,
      "addInteger-memory-arguments-intercept": 1,
      "addInteger-memory-arguments-slope": 1,
      "appendByteString-cpu-arguments-intercept": 1000,
      "appendByteString-cpu-arguments-slope": 173,
      "appendByteString-memory-arguments-intercept": 0,
      "appendByteString-memory-arguments-slope": 1,
      "appendString-cpu-arguments-intercept": 1000,
      "appendString-cpu-arguments-slope": 59957,
      "appendString-memory-arguments-intercept": 4,
      "appendString-memory-arguments-slope": 1,
      "bData-cpu-arguments": 11183,
      "bData-memory-arguments": 32,
      "blake2b_256-cpu-arguments-intercept": 201305,
      "blake2b_256-cpu-arguments-slope": 8356,
      "blake2b_256-memory-arguments": 4,
      "cekApplyCost-exBudgetCPU": 16000,
      "cekApplyCost-exBudgetMemory": 100,
      "cekBuiltinCost-exBudgetCPU": 16000,
      "cekBuiltinCost-exBudgetMemory": 100,
      "cekConstCost-exBudgetCPU": 16000,
      "cekConstCost-exBudgetMemory": 100,
      "cekDelayCost-exBudgetCPU": 16000,
      "cekDelayCost-exBudgetMemory": 100,
      "cekForceCost-exBudgetCPU": 16000,
      "cekForceCost-exBudgetMemory": 100,
      "cekLamCost-exBudgetCPU": 16000,
      "cekLamCost-exBudgetMemory": 100,
      "cekStartupCost-exBudgetCPU": 100,
      "cekStartupCost-exBudgetMemory": 100,
      "cekVarCost-exBudgetCPU": 16000,
      "cekVarCost-exBudgetMemory": 100,
      "chooseData-cpu-arguments": 94375,
      "chooseData-memory-arguments": 32,
      "chooseList-cpu-arguments": 132994,
      "chooseList-memory-arguments": 32,
      "chooseUnit-cpu-arguments": 61462,
      "chooseUnit-memory-arguments": 4,
      "consByteString-cpu-arguments-intercept": 72010,
      "consByteString-cpu-arguments-slope": 178,
      "consByteString-memory-arguments-intercept": 0,
      "consByteString-memory-arguments-slope": 1,
      "constrData-cpu-arguments": 22151,
      "constrData-memory-arguments": 32,
      "decodeUtf8-cpu-arguments-intercept": 91189,
      "decodeUtf8-cpu-arguments-slope": 769,
      "decodeUtf8-memory-arguments-intercept": 4,
      "decodeUtf8-memory-arguments-slope": 2,
      "divideInteger-cpu-arguments-constant": 85848,
      "divideInteger-cpu-arguments-model-arguments-intercept": 228465,
      "divideInteger-cpu-arguments-model-arguments-slope": 122,
      "divideInteger-memory-arguments-intercept": 0,
      "divideInteger-memory-arguments-minimum": 1,
      "divideInteger-memory-arguments-slope": 1,
      "encodeUtf8-cpu-arguments-intercept": 1000,
      "encodeUtf8-cpu-arguments-slope": 42921,
      "encodeUtf8-memory-arguments-intercept": 4,
      "encodeUtf8-memory-arguments-slope": 2,
      "equalsByteString-cpu-arguments-constant": 24548,
      "equalsByteString-cpu-arguments-intercept": 29498,
      "equalsByteString-cpu-arguments-slope": 38,
      "equalsByteString-memory-arguments": 1,
      "equalsData-cpu-arguments-intercept": 898148,
      "equalsData-cpu-arguments-slope": 27279,
      "equalsData-memory-arguments": 1,
      "equalsInteger-cpu-arguments-intercept": 51775,
      "equalsInteger-cpu-arguments-slope": 558,
      "equalsInteger-memory-arguments": 1,
      "equalsString-cpu-arguments-constant": 39184,
      "equalsString-cpu-arguments-intercept": 1000,
      "equalsString-cpu-arguments-slope": 60594,
      "equalsString-memory-arguments": 1,
      "fstPair-cpu-arguments": 141895,
      "fstPair-memory-arguments": 32,
      "headList-cpu-arguments": 83150,
      "headList-memory-arguments": 32,
      "iData-cpu-arguments": 15299,
      "iData-memory-arguments": 32,
      "ifThenElse-cpu-arguments": 76049,
      "ifThenElse-memory-arguments": 1,
      "indexByteString-cpu-arguments": 13169,
      "indexByteString-memory-arguments": 4,
      "lengthOfByteString-cpu-arguments": 22100,
      "lengthOfByteString-memory-arguments": 10,
      "lessThanByteString-cpu-arguments-intercept": 28999,
      "lessThanByteString-cpu-arguments-slope": 74,
      "lessThanByteString-memory-arguments": 1,
      "lessThanEqualsByteString-cpu-arguments-intercept": 28999,
      "lessThanEqualsByteString-cpu-arguments-slope": 74,
      "lessThanEqualsByteString-memory-arguments": 1,
      "lessThanEqualsInteger-cpu-arguments-intercept": 43285,
      "lessThanEqualsInteger-cpu-arguments-slope": 552,
      "lessThanEqualsInteger-memory-arguments": 1,
      "lessThanInteger-cpu-arguments-intercept": 44749,
      "lessThanInteger-cpu-arguments-slope": 541,
      "lessThanInteger-memory-arguments": 1,
      "listData-cpu-arguments": 33852,
      "listData-memory-arguments": 32,
      "mapData-cpu-arguments": 68246,
      "mapData-memory-arguments": 32,
      "mkCons-cpu-arguments": 72362,
      "mkCons-memory-arguments": 32,
      "mkNilData-cpu-arguments": 7243,
      "mkNilData-memory-arguments": 32,
      "mkNilPairData-cpu-arguments": 7391,
      "mkNilPairData-memory-arguments": 32,
      "mkPairData-cpu-arguments": 11546,
      "mkPairData-memory-arguments": 32,
      "modInteger-cpu-arguments-constant": 85848,
      "modInteger-cpu-arguments-model-arguments-intercept": 228465,
      "modInteger-cpu-arguments-model-arguments-slope": 122,
      "modInteger-memory-arguments-intercept": 0,
      "modInteger-memory-arguments-minimum": 1,
      "modInteger-memory-arguments-slope": 1,
      "multiplyInteger-cpu-arguments-intercept": 90434,
      "multiplyInteger-cpu-arguments-slope": 519,
      "multiplyInteger-memory-arguments-intercept": 0,
      "multiplyInteger-memory-arguments-slope": 1,
      "nullList-cpu-arguments": 74433,
      "nullList-memory-arguments": 32,
      "quotientInteger-cpu-arguments-constant": 85848,
      "quotientInteger-cpu-arguments-model-arguments-intercept": 228465,
      "quotientInteger-cpu-arguments-model-arguments-slope": 122,
      "quotientInteger-memory-arguments-intercept": 0,
      "quotientInteger-memory-arguments-minimum": 1,
      "quotientInteger-memory-arguments-slope": 1,
      "remainderInteger-cpu-arguments-constant": 85848,
      "remainderInteger-cpu-arguments-model-arguments-intercept": 228465,
      "remainderInteger-cpu-arguments-model-arguments-slope": 122,
      "remainderInteger-memory-arguments-intercept": 0,
      "remainderInteger-memory-arguments-minimum": 1,
      "remainderInteger-memory-arguments-slope": 1,
      "serialiseData-cpu-arguments-intercept": 955506,
      "serialiseData-cpu-arguments-slope": 213312,
      "serialiseData-memory-arguments-intercept": 0,
      "serialiseData-memory-arguments-slope": 2,
      "sha2_256-cpu-arguments-intercept": 270652,
      "sha2_256-cpu-arguments-slope": 22588,
      "sha2_256-memory-arguments": 4,
      "sha3_256-cpu-arguments-intercept": 1457325,
      "sha3_256-cpu-arguments-slope": 64566,
      "sha3_256-memory-arguments": 4,
      "sliceByteString-cpu-arguments-intercept": 20467,
      "sliceByteString-cpu-arguments-slope": 1,
      "sliceByteString-memory-arguments-intercept": 4,
      "sliceByteString-memory-arguments-slope": 0,
      "sndPair-cpu-arguments": 141992,
      "sndPair-memory-arguments": 32,
      "subtractInteger-cpu-arguments-intercept": 100788,
      "subtractInteger-cpu-arguments-slope": 420,
      "subtractInteger-memory-arguments-intercept": 1,
      "subtractInteger-memory-arguments-slope": 1,
      "tailList-cpu-arguments": 81663,
      "tailList-memory-arguments": 32,
      "trace-cpu-arguments": 59498,
      "trace-memory-arguments": 32,
      "unBData-cpu-arguments": 20142,
      "unBData-memory-arguments": 32,
      "unConstrData-cpu-arguments": 24588,
      "unConstrData-memory-arguments": 32,
      "unIData-cpu-arguments": 20744,
      "unIData-memory-arguments": 32,
      "unListData-cpu-arguments": 25933,
      "unListData-memory-arguments": 32,
      "unMapData-cpu-arguments": 24623,
      "unMapData-memory-arguments": 32,
      "verifyEcdsaSecp256k1Signature-cpu-arguments": 43053543,
      "verifyEcdsaSecp256k1Signature-memory-arguments": 10,
      "verifyEd25519Signature-cpu-arguments-intercept": 53384111,
      "verifyEd25519Signature-cpu-arguments-slope": 14333,
      "verifyEd25519Signature-memory-arguments": 10,
      "verifySchnorrSecp256k1Signature-cpu-arguments-intercept": 43574283,
      "verifySchnorrSecp256k1Signature-cpu-arguments-slope": 26308,
      "verifySchnorrSecp256k1Signature-memory-arguments": 10
    },
    "PlutusV3": {
      "addInteger-cpu-arguments-intercept": 100788,
      "addInteger-cpu-arguments-slope": 420,
      "addInteger-memory-arguments-intercept": 1,
      "addInteger-memory-arguments-slope": 1,
      "appendByteString-cpu-arguments-intercept": 1000,
      "appendByteString-cpu-arguments-slope": 173,
      "appendByteString-memory-arguments-intercept": 0,
      "appendByteString-memory-arguments-slope": 1,
      "appendString-cpu-arguments-intercept": 1000,
      "appendString-cpu-arguments-slope": 59957,
      "appendString-memory-arguments-intercept": 4,
      "appendString-memory-arguments-slope": 1,
      "bData-cpu-arguments": 11183,
      "bData-memory-arguments": 32,
      "blake2b_256-cpu-arguments-intercept": 201305,
      "blake2b_256-cpu-arguments-slope": 8356,
      "blake2b_256-memory-arguments": 4,
      "cekApplyCost-exBudgetCPU": 16000,
      "cekApplyCost-exBudgetMemory": 100,
      "cekBuiltinCost-exBudgetCPU": 16000,
      "cekBuiltinCost-exBudgetMemory": 100,
      "cekConstCost-exBudgetCPU": 16000,
      "cekConstCost-exBudgetMemory": 100,
      "cekDelayCost-exBudgetCPU": 16000,
      "cekDelayCost-exBudgetMemory": 100,
      "cekForceCost-exBudgetCPU": 16000,
      "cekForceCost-exBudgetMemory": 100,
      "cekLamCost-exBudgetCPU": 16000,
      "cekLamCost-exBudgetMemory": 100,
      "cekStartupCost-exBudgetCPU": 100,
      "cekStartupCost-exBudgetMemory": 100,
      "cekVarCost-exBudgetCPU": 16000,
      "cekVarCost-exBudgetMemory": 100,
      "chooseData-cpu-arguments": 94375,
      "chooseData-memory-arguments": 32,
      "chooseList-cpu-arguments": 132994,
      "chooseList-memory-arguments": 32,
      "chooseUnit-cpu-arguments": 61462,
      "chooseUnit-memory-arguments": 4,
      "consByteString-cpu-arguments-intercept": 72010,
      "consByteString-cpu-arguments-slope": 178,
      "consByteString-memory-arguments-intercept": 0,
      "consByteString-memory-arguments-slope": 1,
      "constrData-cpu-arguments": 22151,
      "constrData-memory-arguments": 32,
      "decodeUtf8-cpu-arguments-intercept": 91189,
      "decodeUtf8-cpu-arguments-slope": 769,
      "decodeUtf8-memory-arguments-intercept": 4,
      "decodeUtf8-memory-arguments-slope": 2,
      "divideInteger-cpu-arguments-constant": 85848,
      "divideInteger-cpu-arguments-model-arguments-c00": 123203,
      "divideInteger-cpu-arguments-model-arguments-c01": 7305,
      "divideInteger-cpu-arguments-model-arguments-c02": -900,
      "divideInteger-cpu-arguments-model-arguments-c10": 1716,
      "divideInteger-cpu-arguments-model-arguments-c11": 549,
      "divideInteger-cpu-arguments-model-arguments-c20": 57,
      "divideInteger-cpu-arguments-model-arguments-minimum": 85848,
      "divideInteger-memory-arguments-intercept": 0,
      "divideInteger-memory-arguments-minimum": 1,
      "divideInteger-memory-arguments-slope": 1,
      "encodeUtf8-cpu-arguments-intercept": 1000,
      "encodeUtf8-cpu-arguments-slope": 42921,
      "encodeUtf8-memory-arguments-intercept": 4,
      "encodeUtf8-memory-arguments-slope": 2,
      "equalsByteString-cpu-arguments-constant": 24548,
      "equalsByteString-cpu-arguments-intercept": 29498,
      "equalsByteString-cpu-arguments-slope": 38,
      "equalsByteString-memory-arguments": 1,
      "equalsData-cpu-arguments-intercept": 898148,
      "equalsData-cpu-arguments-slope": 27279,
      "equalsData-memory-arguments": 1,
      "equalsInteger-cpu-arguments-intercept": 51775,
      "equalsInteger-cpu-arguments-slope": 558,
      "equalsInteger-memory-arguments": 1,
      "equalsString-cpu-arguments-constant": 39184,
      "equalsString-cpu-arguments-intercept": 1000,
      "equalsString-cpu-arguments-slope": 60594,
      "equalsString-memory-arguments": 1,
      "fstPair-cpu-arguments": 141895,
      "fstPair-memory-arguments": 32,
      "headList-cpu-arguments": 83150,
      "headList-memory-arguments": 32,
      "iData-cpu-arguments": 15299,
      "iData-memory-arguments": 32,
      "ifThenElse-cpu-arguments": 76049,
      "ifThenElse-memory-arguments": 1,
      "indexByteString-cpu-arguments": 13169,
      "indexByteString-memory-arguments": 4,
      "lengthOfByteString-cpu-arguments": 22100,
      "lengthOfByteString-memory-arguments": 10,
      "lessThanByteString-cpu-arguments-intercept": 28999,
      "lessThanByteString-cpu-arguments-slope": 74,
      "lessThanByteString-memory-arguments": 1,
      "lessThanEqualsByteString-cpu-arguments-intercept": 28999,
      "lessThanEqualsByteString-cpu-arguments-slope": 74,
      "lessThanEqualsByteString-memory-arguments": 1,
      "lessThanEqualsInteger-cpu-arguments-intercept": 43285,
      "lessThanEqualsInteger-cpu-arguments-slope": 552,
      "lessThanEqualsInteger-memory-arguments": 1,
      "lessThanInteger-cpu-arguments-intercept": 44749,
      "lessThanInteger-cpu-arguments-slope": 541,
      "lessThanInteger-memory-arguments": 1,
      "listData-cpu-arguments": 33852,
      "listData-memory-arguments": 32,
      "mapData-cpu-arguments": 68246,
      "mapData-memory-arguments": 32,
      "mkCons-cpu-arguments": 72362,
      "mkCons-memory-arguments": 32,
      "mkNilData-cpu-arguments": 7243,
      "mkNilData-memory-arguments": 32,
      "mkNilPairData-cpu-arguments": 7391,
      "mkNilPairData-memory-arguments": 32,
      "mkPairData-cpu-arguments": 11546,
      "mkPairData-memory-arguments": 32,
      "modInteger-cpu-arguments-constant": 85848,
      "modInteger-cpu-arguments-model-arguments-c00": 123203,
      "modInteger-cpu-arguments-model-arguments-c01": 7305,
      "modInteger-cpu-arguments-model-arguments-c02": -900,
      "modInteger-cpu-arguments-model-arguments-c10": 1716,
      "modInteger-cpu-arguments-model-arguments-c11": 549,
      "modInteger-cpu-arguments-model-arguments-c20": 57,
      "modInteger-cpu-arguments-model-arguments-minimum": 85848,
      "modInteger-memory-arguments-intercept": 0,
      "modInteger-memory-arguments-slope": 1,
      "multiplyInteger-cpu-arguments-intercept": 90434,
      "multiplyInteger-cpu-arguments-slope": 519,
      "multiplyInteger-memory-arguments-intercept": 0,
      "multiplyInteger-memory-arguments-slope": 1,
      "nullList-cpu-arguments": 74433,
      "nullList-memory-arguments": 32,
      "quotientInteger-cpu-arguments-constant": 85848,
      "quotientInteger-cpu-arguments-model-arguments-c00": 123203,
      "quotientInteger-cpu-arguments-model-arguments-c01": 7305,
      "quotientInteger-cpu-arguments-model-arguments-c02": -900,
      "quotientInteger-cpu-arguments-model-arguments-c10": 1716,
      "quotientInteger-cpu-arguments-model-arguments-c11": 549,
      "quotientInteger-cpu-arguments-model-arguments-c20": 57,
      "quotientInteger-cpu-arguments-model-arguments-minimum": 85848,
      "quotientInteger-memory-arguments-intercept": 0,
      "quotientInteger-memory-arguments-slope": 1,
      "remainderInteger-cpu-arguments-constant": 1,
      "remainderInteger-cpu-arguments-model-arguments-c00": 85848,
      "remainderInteger-cpu-arguments-model-arguments-c01": 123203,
      "remainderInteger-cpu-arguments-model-arguments-c02": 7305,
      "remainderInteger-cpu-arguments-model-arguments-c10": -900,
      "remainderInteger-cpu-arguments-model-arguments-c11": 1716,
      "remainderInteger-cpu-arguments-model-arguments-c20": 549,
      "remainderInteger-cpu-arguments-model-arguments-minimum": 57,
      "remainderInteger-memory-arguments-intercept": 85848,
      "remainderInteger-memory-arguments-minimum": 0,
      "remainderInteger-memory-arguments-slope": 1,
      "serialiseData-cpu-arguments-intercept": 955506,
      "serialiseData-cpu-arguments-slope": 213312,
      "serialiseData-memory-arguments-intercept": 0,
      "serialiseData-memory-arguments-slope": 2,
      "sha2_256-cpu-arguments-intercept": 270652,
      "sha2_256-cpu-arguments-slope": 22588,
      "sha2_256-memory-arguments": 4,
      "sha3_256-cpu-arguments-intercept": 1457325,
      "sha3_256-cpu-arguments-slope": 64566,
      "sha3_256-memory-arguments": 4,
      "sliceByteString-cpu-arguments-intercept": 20467,
      "sliceByteString-cpu-arguments-slope": 1,
      "sliceByteString-memory-arguments-intercept": 4,
      "sliceByteString-memory-arguments-slope": 0,
      "sndPair-cpu-arguments": 141992,
      "sndPair-memory-arguments": 32,
      "subtractInteger-cpu-arguments-intercept": 100788,
      "subtractInteger-cpu-arguments-slope": 420,
      "subtractInteger-memory-arguments-intercept": 1,
      "subtractInteger-memory-arguments-slope": 1,
      "tailList-cpu-arguments": 81663,
      "tailList-memory-arguments": 32,
      "trace-cpu-arguments": 59498,
      "trace-memory-arguments": 32,
      "unBData-cpu-arguments": 20142,
      "unBData-memory-arguments": 32,
      "unConstrData-cpu-arguments": 24588,
      "unConstrData-memory-arguments": 32,
      "unIData-cpu-arguments": 20744,
      "unIData-memory-arguments": 32,
      "unListData-cpu-arguments": 25933,
      "unListData-memory-arguments": 32,
      "unMapData-cpu-arguments": 24623,
      "unMapData-memory-arguments": 32,
      "verifyEcdsaSecp256k1Signature-cpu-arguments": 43053543,
      "verifyEcdsaSecp256k1Signature-memory-arguments": 10,
      "verifyEd25519Signature-cpu-arguments-intercept": 53384111,
      "verifyEd25519Signature-cpu-arguments-slope": 14333,
      "verifyEd25519Signature-memory-arguments": 10,
      "verifySchnorrSecp256k1Signature-cpu-arguments-intercept": 43574283,
      "verifySchnorrSecp256k1Signature-cpu-arguments-slope": 26308,
      "verifySchnorrSecp256k1Signature-memory-arguments": 10,
      "cekConstrCost-exBudgetCPU": 16000,
      "cekConstrCost-exBudgetMemory": 100,
      "cekCaseCost-exBudgetCPU": 16000,
      "cekCaseCost-exBudgetMemory": 100,
      "bls12_381_G1_add-cpu-arguments": 962335,
      "bls12_381_G1_add-memory-arguments": 18,
      "bls12_381_G1_compress-cpu-arguments": 2780678,
      "bls12_381_G1_compress-memory-arguments": 6,
      "bls12_381_G1_equal-cpu-arguments": 442008,
      "bls12_381_G1_equal-memory-arguments": 1,
      "bls12_381_G1_hashToGroup-cpu-arguments-intercept": 52538055,
      "bls12_381_G1_hashToGroup-cpu-arguments-slope": 3756,
      "bls12_381_G1_hashToGroup-memory-arguments": 18,
      "bls12_381_G1_neg-cpu-arguments": 267929,
      "bls12_381_G1_neg-memory-arguments": 18,
      "bls12_381_G1_scalarMul-cpu-arguments-intercept": 76433006,
      "bls12_381_G1_scalarMul-cpu-arguments-slope": 8868,
      "bls12_381_G1_scalarMul-memory-arguments": 18,
      "bls12_381_G1_uncompress-cpu-arguments": 52948122,
      "bls12_381_G1_uncompress-memory-arguments": 18,
      "bls12_381_G2_add-cpu-arguments": 1995836,
      "bls12_381_G2_add-memory-arguments": 36,
      "bls12_381_G2_compress-cpu-arguments": 3227919,
      "bls12_381_G2_compress-memory-arguments": 12,
      "bls12_381_G2_equal-cpu-arguments": 901022,
      "bls12_381_G2_equal-memory-arguments": 1,
      "bls12_381_G2_hashToGroup-cpu-arguments-intercept": 166917843,
      "bls12_381_G2_hashToGroup-cpu-arguments-slope": 4307,
      "bls12_381_G2_hashToGroup-memory-arguments": 36,
      "bls12_381_G2_neg-cpu-arguments": 284546,
      "bls12_381_G2_neg-memory-arguments": 36,
      "bls12_381_G2_scalarMul-cpu-arguments-intercept": 158221314,
      "bls12_381_G2_scalarMul-cpu-arguments-slope": 26549,
      "bls12_381_G2_scalarMul-memory-arguments": 36,
      "bls12_381_G2_uncompress-cpu-arguments": 74698472,
      "bls12_381_G2_uncompress-memory-arguments": 36,
      "bls12_381_finalVerify-cpu-arguments": 333849714,
      "bls12_381_finalVerify-memory-arguments": 1,
      "bls12_381_millerLoop-cpu-arguments": 254006273,
      "bls12_381_millerLoop-memory-arguments": 72,
      "bls12_381_mulMlResult-cpu-arguments": 2174038,
      "bls12_381_mulMlResult-memory-arguments": 72,
      "keccak_256-cpu-arguments-intercept": 2261318,
      "keccak_256-cpu-arguments-slope": 64571,
      "keccak_256-memory-arguments": 4,
      "blake2b_224-cpu-arguments-intercept": 207616,
      "blake2b_224-cpu-arguments-slope": 8310,
      "blake2b_224-memory-arguments": 4,
      "integerToByteString-cpu-arguments-c0": 1293828,
      "integerToByteString-cpu-arguments-c1": 28716,
      "integerToByteString-cpu-arguments-c2": 63,
      "integerToByteString-memory-arguments-intercept": 0,
      "integerToByteString-memory-arguments-slope": 1,
      "byteStringToInteger-cpu-arguments-c0": 1006041,
      "byteStringToInteger-cpu-arguments-c1": 43623,
      "byteStringToInteger-cpu-arguments-c2": 251,
      "byteStringToInteger-memory-arguments-intercept": 0,
      "byteStringToInteger-memory-arguments-slope": 1
    }
  },
  "price_mem": 0.0577,
  "price_step": 0.0000721,
  "max_tx_ex_mem": "14000000",
  "max_tx_ex_steps": "10000000000",
  "max_block_ex_mem": "62000000",
  "max_block_ex_steps": "20000000000",
  "max_val_size": "5000",
  "collateral_percent": 150,
  "max_collateral_inputs": 3,
  "coins_per_utxo_size": "4310",
  "coins_per_utxo_word": "4310",
  "pvt_motion_no_confidence": 0.51,
  "pvt_committee_normal": 0.51,
  "pvt_committee_no_confidence": 0.51,
  "pvt_hard_fork_initiation": 0.51,
  "dvt_motion_no_confidence": 0.67,
  "dvt_committee_normal": 0.67,
  "dvt_committee_no_confidence": 0.6,
  "dvt_update_to_constitution": 0.75,
  "dvt_hard_fork_initiation": 0.6,
  "dvt_p_p_network_group": 0.67,
  "dvt_p_p_economic_group": 0.67,
  "dvt_p_p_technical_group": 0.67,
  "dvt_p_p_gov_group": 0.75,
  "dvt_treasury_withdrawal": 0.67,
  "committee_min_size": "7",
  "committee_max_term_length": "146",
  "gov_action_lifetime": "6",
  "gov_action_deposit": "100000000000",
  "drep_deposit": "500000000",
  "drep_activity": "20",
  "pvtpp_security_group": 0.51,
  "min_fee_ref_script_cost_per_byte": 15
}
```

And here is what was returned for 405 epoch:

```
{
  "epoch": 405,
  "min_fee_a": 44,
  "min_fee_b": 155381,
  "max_block_size": 90112,
  "max_tx_size": 16384,
  "max_block_header_size": 1100,
  "key_deposit": "2000000",
  "pool_deposit": "500000000",
  "e_max": 18,
  "n_opt": 500,
  "a0": 0.3,
  "rho": 0.003,
  "tau": 0.2,
  "decentralisation_param": 0,
  "extra_entropy": null,
  "protocol_major_ver": 8,
  "protocol_minor_ver": 0,
  "min_utxo": "4310",
  "min_pool_cost": "340000000",
  "nonce": "0e339939685e15fb51aa20cdef3f963c8adac93d5233dd490f3969b4842d00c5",
  "cost_models": {
    "PlutusV1": {
      "addInteger-cpu-arguments-intercept": 205665,
      "addInteger-cpu-arguments-slope": 812,
      "addInteger-memory-arguments-intercept": 1,
      "addInteger-memory-arguments-slope": 1,
      "appendByteString-cpu-arguments-intercept": 1000,
      "appendByteString-cpu-arguments-slope": 571,
      "appendByteString-memory-arguments-intercept": 0,
      "appendByteString-memory-arguments-slope": 1,
      "appendString-cpu-arguments-intercept": 1000,
      "appendString-cpu-arguments-slope": 24177,
      "appendString-memory-arguments-intercept": 4,
      "appendString-memory-arguments-slope": 1,
      "bData-cpu-arguments": 1000,
      "bData-memory-arguments": 32,
      "blake2b_256-cpu-arguments-intercept": 117366,
      "blake2b_256-cpu-arguments-slope": 10475,
      "blake2b_256-memory-arguments": 4,
      "cekApplyCost-exBudgetCPU": 23000,
      "cekApplyCost-exBudgetMemory": 100,
      "cekBuiltinCost-exBudgetCPU": 23000,
      "cekBuiltinCost-exBudgetMemory": 100,
      "cekConstCost-exBudgetCPU": 23000,
      "cekConstCost-exBudgetMemory": 100,
      "cekDelayCost-exBudgetCPU": 23000,
      "cekDelayCost-exBudgetMemory": 100,
      "cekForceCost-exBudgetCPU": 23000,
      "cekForceCost-exBudgetMemory": 100,
      "cekLamCost-exBudgetCPU": 23000,
      "cekLamCost-exBudgetMemory": 100,
      "cekStartupCost-exBudgetCPU": 100,
      "cekStartupCost-exBudgetMemory": 100,
      "cekVarCost-exBudgetCPU": 23000,
      "cekVarCost-exBudgetMemory": 100,
      "chooseData-cpu-arguments": 19537,
      "chooseData-memory-arguments": 32,
      "chooseList-cpu-arguments": 175354,
      "chooseList-memory-arguments": 32,
      "chooseUnit-cpu-arguments": 46417,
      "chooseUnit-memory-arguments": 4,
      "consByteString-cpu-arguments-intercept": 221973,
      "consByteString-cpu-arguments-slope": 511,
      "consByteString-memory-arguments-intercept": 0,
      "consByteString-memory-arguments-slope": 1,
      "constrData-cpu-arguments": 89141,
      "constrData-memory-arguments": 32,
      "decodeUtf8-cpu-arguments-intercept": 497525,
      "decodeUtf8-cpu-arguments-slope": 14068,
      "decodeUtf8-memory-arguments-intercept": 4,
      "decodeUtf8-memory-arguments-slope": 2,
      "divideInteger-cpu-arguments-constant": 196500,
      "divideInteger-cpu-arguments-model-arguments-intercept": 453240,
      "divideInteger-cpu-arguments-model-arguments-slope": 220,
      "divideInteger-memory-arguments-intercept": 0,
      "divideInteger-memory-arguments-minimum": 1,
      "divideInteger-memory-arguments-slope": 1,
      "encodeUtf8-cpu-arguments-intercept": 1000,
      "encodeUtf8-cpu-arguments-slope": 28662,
      "encodeUtf8-memory-arguments-intercept": 4,
      "encodeUtf8-memory-arguments-slope": 2,
      "equalsByteString-cpu-arguments-constant": 245000,
      "equalsByteString-cpu-arguments-intercept": 216773,
      "equalsByteString-cpu-arguments-slope": 62,
      "equalsByteString-memory-arguments": 1,
      "equalsData-cpu-arguments-intercept": 1060367,
      "equalsData-cpu-arguments-slope": 12586,
      "equalsData-memory-arguments": 1,
      "equalsInteger-cpu-arguments-intercept": 208512,
      "equalsInteger-cpu-arguments-slope": 421,
      "equalsInteger-memory-arguments": 1,
      "equalsString-cpu-arguments-constant": 187000,
      "equalsString-cpu-arguments-intercept": 1000,
      "equalsString-cpu-arguments-slope": 52998,
      "equalsString-memory-arguments": 1,
      "fstPair-cpu-arguments": 80436,
      "fstPair-memory-arguments": 32,
      "headList-cpu-arguments": 43249,
      "headList-memory-arguments": 32,
      "iData-cpu-arguments": 1000,
      "iData-memory-arguments": 32,
      "ifThenElse-cpu-arguments": 80556,
      "ifThenElse-memory-arguments": 1,
      "indexByteString-cpu-arguments": 57667,
      "indexByteString-memory-arguments": 4,
      "lengthOfByteString-cpu-arguments": 1000,
      "lengthOfByteString-memory-arguments": 10,
      "lessThanByteString-cpu-arguments-intercept": 197145,
      "lessThanByteString-cpu-arguments-slope": 156,
      "lessThanByteString-memory-arguments": 1,
      "lessThanEqualsByteString-cpu-arguments-intercept": 197145,
      "lessThanEqualsByteString-cpu-arguments-slope": 156,
      "lessThanEqualsByteString-memory-arguments": 1,
      "lessThanEqualsInteger-cpu-arguments-intercept": 204924,
      "lessThanEqualsInteger-cpu-arguments-slope": 473,
      "lessThanEqualsInteger-memory-arguments": 1,
      "lessThanInteger-cpu-arguments-intercept": 208896,
      "lessThanInteger-cpu-arguments-slope": 511,
      "lessThanInteger-memory-arguments": 1,
      "listData-cpu-arguments": 52467,
      "listData-memory-arguments": 32,
      "mapData-cpu-arguments": 64832,
      "mapData-memory-arguments": 32,
      "mkCons-cpu-arguments": 65493,
      "mkCons-memory-arguments": 32,
      "mkNilData-cpu-arguments": 22558,
      "mkNilData-memory-arguments": 32,
      "mkNilPairData-cpu-arguments": 16563,
      "mkNilPairData-memory-arguments": 32,
      "mkPairData-cpu-arguments": 76511,
      "mkPairData-memory-arguments": 32,
      "modInteger-cpu-arguments-constant": 196500,
      "modInteger-cpu-arguments-model-arguments-intercept": 453240,
      "modInteger-cpu-arguments-model-arguments-slope": 220,
      "modInteger-memory-arguments-intercept": 0,
      "modInteger-memory-arguments-minimum": 1,
      "modInteger-memory-arguments-slope": 1,
      "multiplyInteger-cpu-arguments-intercept": 69522,
      "multiplyInteger-cpu-arguments-slope": 11687,
      "multiplyInteger-memory-arguments-intercept": 0,
      "multiplyInteger-memory-arguments-slope": 1,
      "nullList-cpu-arguments": 60091,
      "nullList-memory-arguments": 32,
      "quotientInteger-cpu-arguments-constant": 196500,
      "quotientInteger-cpu-arguments-model-arguments-intercept": 453240,
      "quotientInteger-cpu-arguments-model-arguments-slope": 220,
      "quotientInteger-memory-arguments-intercept": 0,
      "quotientInteger-memory-arguments-minimum": 1,
      "quotientInteger-memory-arguments-slope": 1,
      "remainderInteger-cpu-arguments-constant": 196500,
      "remainderInteger-cpu-arguments-model-arguments-intercept": 453240,
      "remainderInteger-cpu-arguments-model-arguments-slope": 220,
      "remainderInteger-memory-arguments-intercept": 0,
      "remainderInteger-memory-arguments-minimum": 1,
      "remainderInteger-memory-arguments-slope": 1,
      "sha2_256-cpu-arguments-intercept": 806990,
      "sha2_256-cpu-arguments-slope": 30482,
      "sha2_256-memory-arguments": 4,
      "sha3_256-cpu-arguments-intercept": 1927926,
      "sha3_256-cpu-arguments-slope": 82523,
      "sha3_256-memory-arguments": 4,
      "sliceByteString-cpu-arguments-intercept": 265318,
      "sliceByteString-cpu-arguments-slope": 0,
      "sliceByteString-memory-arguments-intercept": 4,
      "sliceByteString-memory-arguments-slope": 0,
      "sndPair-cpu-arguments": 85931,
      "sndPair-memory-arguments": 32,
      "subtractInteger-cpu-arguments-intercept": 205665,
      "subtractInteger-cpu-arguments-slope": 812,
      "subtractInteger-memory-arguments-intercept": 1,
      "subtractInteger-memory-arguments-slope": 1,
      "tailList-cpu-arguments": 41182,
      "tailList-memory-arguments": 32,
      "trace-cpu-arguments": 212342,
      "trace-memory-arguments": 32,
      "unBData-cpu-arguments": 31220,
      "unBData-memory-arguments": 32,
      "unConstrData-cpu-arguments": 32696,
      "unConstrData-memory-arguments": 32,
      "unIData-cpu-arguments": 43357,
      "unIData-memory-arguments": 32,
      "unListData-cpu-arguments": 32247,
      "unListData-memory-arguments": 32,
      "unMapData-cpu-arguments": 38314,
      "unMapData-memory-arguments": 32,
      "verifyEd25519Signature-cpu-arguments-intercept": 57996947,
      "verifyEd25519Signature-cpu-arguments-slope": 18975,
      "verifyEd25519Signature-memory-arguments": 10
    },
    "PlutusV2": {
      "addInteger-cpu-arguments-intercept": 205665,
      "addInteger-cpu-arguments-slope": 812,
      "addInteger-memory-arguments-intercept": 1,
      "addInteger-memory-arguments-slope": 1,
      "appendByteString-cpu-arguments-intercept": 1000,
      "appendByteString-cpu-arguments-slope": 571,
      "appendByteString-memory-arguments-intercept": 0,
      "appendByteString-memory-arguments-slope": 1,
      "appendString-cpu-arguments-intercept": 1000,
      "appendString-cpu-arguments-slope": 24177,
      "appendString-memory-arguments-intercept": 4,
      "appendString-memory-arguments-slope": 1,
      "bData-cpu-arguments": 1000,
      "bData-memory-arguments": 32,
      "blake2b_256-cpu-arguments-intercept": 117366,
      "blake2b_256-cpu-arguments-slope": 10475,
      "blake2b_256-memory-arguments": 4,
      "cekApplyCost-exBudgetCPU": 23000,
      "cekApplyCost-exBudgetMemory": 100,
      "cekBuiltinCost-exBudgetCPU": 23000,
      "cekBuiltinCost-exBudgetMemory": 100,
      "cekConstCost-exBudgetCPU": 23000,
      "cekConstCost-exBudgetMemory": 100,
      "cekDelayCost-exBudgetCPU": 23000,
      "cekDelayCost-exBudgetMemory": 100,
      "cekForceCost-exBudgetCPU": 23000,
      "cekForceCost-exBudgetMemory": 100,
      "cekLamCost-exBudgetCPU": 23000,
      "cekLamCost-exBudgetMemory": 100,
      "cekStartupCost-exBudgetCPU": 100,
      "cekStartupCost-exBudgetMemory": 100,
      "cekVarCost-exBudgetCPU": 23000,
      "cekVarCost-exBudgetMemory": 100,
      "chooseData-cpu-arguments": 19537,
      "chooseData-memory-arguments": 32,
      "chooseList-cpu-arguments": 175354,
      "chooseList-memory-arguments": 32,
      "chooseUnit-cpu-arguments": 46417,
      "chooseUnit-memory-arguments": 4,
      "consByteString-cpu-arguments-intercept": 221973,
      "consByteString-cpu-arguments-slope": 511,
      "consByteString-memory-arguments-intercept": 0,
      "consByteString-memory-arguments-slope": 1,
      "constrData-cpu-arguments": 89141,
      "constrData-memory-arguments": 32,
      "decodeUtf8-cpu-arguments-intercept": 497525,
      "decodeUtf8-cpu-arguments-slope": 14068,
      "decodeUtf8-memory-arguments-intercept": 4,
      "decodeUtf8-memory-arguments-slope": 2,
      "divideInteger-cpu-arguments-constant": 196500,
      "divideInteger-cpu-arguments-model-arguments-intercept": 453240,
      "divideInteger-cpu-arguments-model-arguments-slope": 220,
      "divideInteger-memory-arguments-intercept": 0,
      "divideInteger-memory-arguments-minimum": 1,
      "divideInteger-memory-arguments-slope": 1,
      "encodeUtf8-cpu-arguments-intercept": 1000,
      "encodeUtf8-cpu-arguments-slope": 28662,
      "encodeUtf8-memory-arguments-intercept": 4,
      "encodeUtf8-memory-arguments-slope": 2,
      "equalsByteString-cpu-arguments-constant": 245000,
      "equalsByteString-cpu-arguments-intercept": 216773,
      "equalsByteString-cpu-arguments-slope": 62,
      "equalsByteString-memory-arguments": 1,
      "equalsData-cpu-arguments-intercept": 1060367,
      "equalsData-cpu-arguments-slope": 12586,
      "equalsData-memory-arguments": 1,
      "equalsInteger-cpu-arguments-intercept": 208512,
      "equalsInteger-cpu-arguments-slope": 421,
      "equalsInteger-memory-arguments": 1,
      "equalsString-cpu-arguments-constant": 187000,
      "equalsString-cpu-arguments-intercept": 1000,
      "equalsString-cpu-arguments-slope": 52998,
      "equalsString-memory-arguments": 1,
      "fstPair-cpu-arguments": 80436,
      "fstPair-memory-arguments": 32,
      "headList-cpu-arguments": 43249,
      "headList-memory-arguments": 32,
      "iData-cpu-arguments": 1000,
      "iData-memory-arguments": 32,
      "ifThenElse-cpu-arguments": 80556,
      "ifThenElse-memory-arguments": 1,
      "indexByteString-cpu-arguments": 57667,
      "indexByteString-memory-arguments": 4,
      "lengthOfByteString-cpu-arguments": 1000,
      "lengthOfByteString-memory-arguments": 10,
      "lessThanByteString-cpu-arguments-intercept": 197145,
      "lessThanByteString-cpu-arguments-slope": 156,
      "lessThanByteString-memory-arguments": 1,
      "lessThanEqualsByteString-cpu-arguments-intercept": 197145,
      "lessThanEqualsByteString-cpu-arguments-slope": 156,
      "lessThanEqualsByteString-memory-arguments": 1,
      "lessThanEqualsInteger-cpu-arguments-intercept": 204924,
      "lessThanEqualsInteger-cpu-arguments-slope": 473,
      "lessThanEqualsInteger-memory-arguments": 1,
      "lessThanInteger-cpu-arguments-intercept": 208896,
      "lessThanInteger-cpu-arguments-slope": 511,
      "lessThanInteger-memory-arguments": 1,
      "listData-cpu-arguments": 52467,
      "listData-memory-arguments": 32,
      "mapData-cpu-arguments": 64832,
      "mapData-memory-arguments": 32,
      "mkCons-cpu-arguments": 65493,
      "mkCons-memory-arguments": 32,
      "mkNilData-cpu-arguments": 22558,
      "mkNilData-memory-arguments": 32,
      "mkNilPairData-cpu-arguments": 16563,
      "mkNilPairData-memory-arguments": 32,
      "mkPairData-cpu-arguments": 76511,
      "mkPairData-memory-arguments": 32,
      "modInteger-cpu-arguments-constant": 196500,
      "modInteger-cpu-arguments-model-arguments-intercept": 453240,
      "modInteger-cpu-arguments-model-arguments-slope": 220,
      "modInteger-memory-arguments-intercept": 0,
      "modInteger-memory-arguments-minimum": 1,
      "modInteger-memory-arguments-slope": 1,
      "multiplyInteger-cpu-arguments-intercept": 69522,
      "multiplyInteger-cpu-arguments-slope": 11687,
      "multiplyInteger-memory-arguments-intercept": 0,
      "multiplyInteger-memory-arguments-slope": 1,
      "nullList-cpu-arguments": 60091,
      "nullList-memory-arguments": 32,
      "quotientInteger-cpu-arguments-constant": 196500,
      "quotientInteger-cpu-arguments-model-arguments-intercept": 453240,
      "quotientInteger-cpu-arguments-model-arguments-slope": 220,
      "quotientInteger-memory-arguments-intercept": 0,
      "quotientInteger-memory-arguments-minimum": 1,
      "quotientInteger-memory-arguments-slope": 1,
      "remainderInteger-cpu-arguments-constant": 196500,
      "remainderInteger-cpu-arguments-model-arguments-intercept": 453240,
      "remainderInteger-cpu-arguments-model-arguments-slope": 220,
      "remainderInteger-memory-arguments-intercept": 0,
      "remainderInteger-memory-arguments-minimum": 1,
      "remainderInteger-memory-arguments-slope": 1,
      "serialiseData-cpu-arguments-intercept": 1159724,
      "serialiseData-cpu-arguments-slope": 392670,
      "serialiseData-memory-arguments-intercept": 0,
      "serialiseData-memory-arguments-slope": 2,
      "sha2_256-cpu-arguments-intercept": 806990,
      "sha2_256-cpu-arguments-slope": 30482,
      "sha2_256-memory-arguments": 4,
      "sha3_256-cpu-arguments-intercept": 1927926,
      "sha3_256-cpu-arguments-slope": 82523,
      "sha3_256-memory-arguments": 4,
      "sliceByteString-cpu-arguments-intercept": 265318,
      "sliceByteString-cpu-arguments-slope": 0,
      "sliceByteString-memory-arguments-intercept": 4,
      "sliceByteString-memory-arguments-slope": 0,
      "sndPair-cpu-arguments": 85931,
      "sndPair-memory-arguments": 32,
      "subtractInteger-cpu-arguments-intercept": 205665,
      "subtractInteger-cpu-arguments-slope": 812,
      "subtractInteger-memory-arguments-intercept": 1,
      "subtractInteger-memory-arguments-slope": 1,
      "tailList-cpu-arguments": 41182,
      "tailList-memory-arguments": 32,
      "trace-cpu-arguments": 212342,
      "trace-memory-arguments": 32,
      "unBData-cpu-arguments": 31220,
      "unBData-memory-arguments": 32,
      "unConstrData-cpu-arguments": 32696,
      "unConstrData-memory-arguments": 32,
      "unIData-cpu-arguments": 43357,
      "unIData-memory-arguments": 32,
      "unListData-cpu-arguments": 32247,
      "unListData-memory-arguments": 32,
      "unMapData-cpu-arguments": 38314,
      "unMapData-memory-arguments": 32,
      "verifyEcdsaSecp256k1Signature-cpu-arguments": 35892428,
      "verifyEcdsaSecp256k1Signature-memory-arguments": 10,
      "verifyEd25519Signature-cpu-arguments-intercept": 57996947,
      "verifyEd25519Signature-cpu-arguments-slope": 18975,
      "verifyEd25519Signature-memory-arguments": 10,
      "verifySchnorrSecp256k1Signature-cpu-arguments-intercept": 38887044,
      "verifySchnorrSecp256k1Signature-cpu-arguments-slope": 32947,
      "verifySchnorrSecp256k1Signature-memory-arguments": 10
    }
  },
  "price_mem": 0.0577,
  "price_step": 0.0000721,
  "max_tx_ex_mem": "14000000",
  "max_tx_ex_steps": "10000000000",
  "max_block_ex_mem": "62000000",
  "max_block_ex_steps": "20000000000",
  "max_val_size": "5000",
  "collateral_percent": 150,
  "max_collateral_inputs": 3,
  "coins_per_utxo_size": "4310",
  "coins_per_utxo_word": "4310",
  "pvt_motion_no_confidence": null,
  "pvt_committee_normal": null,
  "pvt_committee_no_confidence": null,
  "pvt_hard_fork_initiation": null,
  "dvt_motion_no_confidence": null,
  "dvt_committee_normal": null,
  "dvt_committee_no_confidence": null,
  "dvt_update_to_constitution": null,
  "dvt_hard_fork_initiation": null,
  "dvt_p_p_network_group": null,
  "dvt_p_p_economic_group": null,
  "dvt_p_p_technical_group": null,
  "dvt_p_p_gov_group": null,
  "dvt_treasury_withdrawal": null,
  "committee_min_size": null,
  "committee_max_term_length": null,
  "gov_action_lifetime": null,
  "gov_action_deposit": null,
  "drep_deposit": null,
  "drep_activity": null,
  "pvtpp_security_group": null,
  "min_fee_ref_script_cost_per_byte": null
}
```

I haven't bothered with Haddock, which can be added by maintainer.