### PR TITLE
Remove To/From JSON (Maybe PoolMetadata)

### DIFF
--- a/blockfrost-api/src/Blockfrost/Types/Cardano/Pools.hs
+++ b/blockfrost-api/src/Blockfrost/Types/Cardano/Pools.hs
@@ -164,17 +164,6 @@ data PoolMetadata = PoolMetadata
   deriving (FromJSON, ToJSON)
   via CustomJSON '[FieldLabelModifier '[StripPrefix "_poolMetadata", CamelToSnake]] PoolMetadata
 
--- We need this more specific
--- instance since API returns
--- empty object if there's no metadata
-instance {-# OVERLAPS #-} ToJSON (Maybe PoolMetadata) where
-  toJSON Nothing   = object mempty
-  toJSON (Just pm) = toJSON pm
-  toEncoding Nothing   = pairs mempty
-  toEncoding (Just pm) = toEncoding pm
-instance {-# OVERLAPS #-} FromJSON (Maybe PoolMetadata) where
-  parseJSON x | x == object [] = pure Nothing
-  parseJSON x = Just <$> parseJSON x
 
 instance ToSample PoolMetadata where
   toSamples = pure $ singleSample samplePoolMetadata


### PR DESCRIPTION
Credit @v0d1ch

We had problems compiling `ToJSON` instances with this `ToJSON (Maybe PoolMetadata)` in scope. As we neither control the instance from `aeson`, nor the one in your package, we cannot make instances like [this one](https://github.com/cardano-scaling/hydra/blob/28e58d9a363afc7ce6484e693fd9ce4db4269ec9/hydra-node/src/Hydra/API/ServerOutput.hs#L109) to compile.

FYI compilation errors coming from this:
```
[12 of 45] Compiling Hydra.Chain.Blockfrost.Client ( src/Hydra/Chain/Blockfrost/Client.hs, /home/ch1bo/code/iog/hydra/dist-newstyle/build/x86_64-linux/ghc-9.6.6/hydra-node-0.21.0/build/Hydra/Chain/Blockfrost/Client.o, /home/ch1bo/code/iog/hydra/dist-newstyle/build/x86_64-linux/ghc-9.6.6/hydra-node-0.21.0/build/Hydra/Chain/Blockfrost/Client.dyn_o )
[18 of 45] Compiling Hydra.API.ServerOutput ( src/Hydra/API/ServerOutput.hs, /home/ch1bo/code/iog/hydra/dist-newstyle/build/x86_64-linux/ghc-9.6.6/hydra-node-0.21.0/build/Hydra/API/ServerOutput.o, /home/ch1bo/code/iog/hydra/dist-newstyle/build/x86_64-linux/ghc-9.6.6/hydra-node-0.21.0/build/Hydra/API/ServerOutput.dyn_o )

src/Hydra/API/ServerOutput.hs:112:5: error: [GHC-43085]
    • Overlapping instances for ToJSON (Maybe (UTxOType tx))
        arising from a use of ‘genericToJSON’
      Matching instance:
        instance ToJSON a => ToJSON (Maybe a)
          -- Defined in ‘aeson-2.2.3.0:Data.Aeson.Types.ToJSON’
        ...plus one instance involving out-of-scope types
          Potentially matching instance:
            instance [overlap ok] ToJSON
                                    (Maybe
                                       blockfrost-api-0.12.1.0:Blockfrost.Types.Cardano.Pools.PoolMetadata)
      (The choice depends on the instantiation of ‘tx’
       and the result of evaluating ‘UTxOType’
       To pick the first instance above, use IncoherentInstances
       when compiling the other instance declarations)
    • In the expression:
        genericToJSON defaultOptions {omitNothingFields = True}
      In an equation for ‘toJSON’:
          toJSON = genericToJSON defaultOptions {omitNothingFields = True}
      In the instance declaration for ‘ToJSON (Greetings tx)’
    |
112 |     genericToJSON
    |     ^^^^^^^^^^^^^
```

We found that it is important what modules are compiled in one invocation of `cabal build`. For example the above error does not appear if we try another build of `cabal build` which had the module pulling in your instance already compiled (`Hydra.Chain.Blockfrost.Client`).
