### PR TITLE
Avoid overlapping instances using newtype

### DIFF
--- a/blockfrost-api/src/Blockfrost/API/Cardano/Pools.hs
+++ b/blockfrost-api/src/Blockfrost/API/Cardano/Pools.hs
@@ -68,7 +68,7 @@ data PoolsAPI route =
         :> Description "Stake pool registration metadata."
         :> Capture "pool_id" PoolId
         :> "metadata"
-        :> Get '[JSON] (Maybe PoolMetadata)
+        :> Get '[JSON] PoolMetadataResponse
     , _getPoolRelays
         :: route
         :- Summary "Stake pool relays"

--- a/blockfrost-api/test/Cardano/Pools.hs
+++ b/blockfrost-api/test/Cardano/Pools.hs
@@ -45,7 +45,7 @@ spec_pools = do
   it "parses empty object pool metadata sample" $ do
     eitherDecode "{}"
     `shouldBe`
-    Right (Nothing :: Maybe PoolMetadata)
+    Right (PoolMetadataResponse Nothing)
 
   it "parses pool relay sample" $ do
     eitherDecode poolRelaySample

--- a/blockfrost-client/src/Blockfrost/Client/Cardano/Pools.hs
+++ b/blockfrost-client/src/Blockfrost/Client/Cardano/Pools.hs
@@ -117,7 +117,7 @@ getPoolHistory :: MonadBlockfrost m => PoolId -> m [PoolHistory]
 getPoolHistory p = getPoolHistory' p def def
 
 getPoolMetadata_ :: MonadBlockfrost m => Project -> PoolId -> m (Maybe PoolMetadata)
-getPoolMetadata_ = _getPoolMetadata . poolsClient
+getPoolMetadata_ p pid = getMetadata <$> _getPoolMetadata (poolsClient p) pid
 
 -- | Get stake pool metadata
 getPoolMetadata :: MonadBlockfrost m => PoolId -> m (Maybe PoolMetadata)


### PR DESCRIPTION
This avoids defining instances on `Mabye PoolMetadata` by introducing a dedicated type for the response to GET /pools/<id>/metadata.

Alternative to #71 