### PR TITLE
client: mempool API cleanup

### DIFF
--- a/blockfrost-client/example/Main.hs
+++ b/blockfrost-client/example/Main.hs
@@ -17,18 +17,19 @@ main = do
     (ers :: Either BlockfrostError [AccountReward]) <-
       tryError $ getAccountRewards "gonnaFail"
 
+    -- variant accepting @Paged@ and @SortOrder@ arguments
+    -- getAccountRewards' "gonnaFail" (page 10) desc
+
     allMempoolTxs <-
-      getMempoolTransactions prj def def
+      allPages $ \p -> getMempoolTransactions' p def
 
     if null allMempoolTxs
     then return $ (latestBlocks, ers, allMempoolTxs, Nothing)
     else do let lastTxInMempool = TxHash . unTxHashObject $ last allMempoolTxs
-            lastMempoolTx <- getMempoolTransaction prj lastTxInMempool
+            lastMempoolTx <- getMempoolTransaction lastTxInMempool
 
             return (latestBlocks, ers, allMempoolTxs, Just lastMempoolTx) 
 
-  -- variant accepting @Paged@ and @SortOrder@ arguments
-  -- getAccountRewards' "gonnaFail" (page 10) desc
   case res of
     Left e -> print e
     Right ((latestBlocks, ers, allMempoolTxs, lastMempoolTx)) -> do 
@@ -51,7 +52,12 @@ main = do
           case _inputs mempoolTx of
             [] -> print "No mempool transaction inputs found" -- Should be impossible
             (inp:_) -> do
-              let address = Address $ _address inp
-              mempoolTxByAddress <- runBlockfrost prj $ getMempoolTransactionsByAddress prj address def def
-              print "Mempool transactions by address:"
-              print mempoolTxByAddress
+              case _address inp of
+                Nothing -> print "Input has no address"
+                Just addr -> do
+                  mempoolTxByAddress <-
+                    runBlockfrost prj
+                      $ getMempoolTransactionsByAddress
+                          (Address addr)
+                  print "Mempool transactions by address:"
+                  print mempoolTxByAddress

--- a/blockfrost-client/src/Blockfrost/Client.hs
+++ b/blockfrost-client/src/Blockfrost/Client.hs
@@ -122,8 +122,10 @@ module Blockfrost.Client
   , getTxMetadataByLabelCBOR'
     -- Cardano - Mempool
   , getMempoolTransactions
+  , getMempoolTransactions'
   , getMempoolTransaction
   , getMempoolTransactionsByAddress
+  , getMempoolTransactionsByAddress'
     -- Cardano - Network
   , getNetworkInfo
   , getNetworkEras

--- a/blockfrost-client/src/Blockfrost/Client/Cardano/Mempool.hs
+++ b/blockfrost-client/src/Blockfrost/Client/Cardano/Mempool.hs
@@ -2,8 +2,10 @@
 
 module Blockfrost.Client.Cardano.Mempool
   ( getMempoolTransactions
-  , getMempoolTransaction 
+  , getMempoolTransactions'
+  , getMempoolTransaction
   , getMempoolTransactionsByAddress
+  , getMempoolTransactionsByAddress'
   ) where
 
 import Blockfrost.API
@@ -13,12 +15,43 @@ import Blockfrost.Types
 mempoolClient :: MonadBlockfrost m => Project -> MempoolAPI (AsClientT m)
 mempoolClient = fromServant . _mempool . cardanoClient
 
-getMempoolTransactions :: MonadBlockfrost m => Project -> Paged -> SortOrder -> m [TxHashObject]
-getMempoolTransactions = _mempoolTransactions . mempoolClient 
+getMempoolTransactions_ :: MonadBlockfrost m => Project -> Paged -> SortOrder -> m [TxHashObject]
+getMempoolTransactions_ = _mempoolTransactions . mempoolClient
 
-getMempoolTransaction :: MonadBlockfrost m => Project -> TxHash -> m MempoolTransaction
-getMempoolTransaction = _specificTransaction . mempoolClient  
+-- | Get a list of transactions currently in Blockfrost.io mempool
+-- Allows custom paging and ordering using 'Paged' and 'SortOrder'.
+getMempoolTransactions' :: MonadBlockfrost m => Paged -> SortOrder -> m [TxHashObject]
+getMempoolTransactions' pg s = go (\p -> getMempoolTransactions_ p pg s)
 
-getMempoolTransactionsByAddress :: MonadBlockfrost m => Project -> Address -> Paged -> SortOrder -> m [TxHashObject]
-getMempoolTransactionsByAddress = _specificAddress . mempoolClient 
+-- | Get a list of transactions currently in Blockfrost.io mempool
+--
+-- Queries 100 entries. To query all entries use 'Blockfrost.Client.Core.allPages'
+-- with principled variant of this function (suffixed with @'@)
+-- that accepts 'Paged' argument.
+getMempoolTransactions :: MonadBlockfrost m => m [TxHashObject]
+getMempoolTransactions = getMempoolTransactions' def def
 
+getMempoolTransaction_ :: MonadBlockfrost m => Project -> TxHash -> m MempoolTransaction
+getMempoolTransaction_ = _specificTransaction . mempoolClient
+
+-- | Get details about a specific @MempoolTransaction@
+getMempoolTransaction :: MonadBlockfrost m => TxHash -> m MempoolTransaction
+getMempoolTransaction t = go (`getMempoolTransaction_` t)
+
+getMempoolTransactionsByAddress_ :: MonadBlockfrost m => Project -> Address -> Paged -> SortOrder -> m [TxHashObject]
+getMempoolTransactionsByAddress_ = _specificAddress . mempoolClient
+
+-- | Get a list of transactions currently in Blockfrost.io mempool
+-- where at least one of the transaction inputs or outputs belongs to the address.
+-- Allows custom paging and ordering using 'Paged' and 'SortOrder'.
+getMempoolTransactionsByAddress' :: MonadBlockfrost m => Address -> Paged -> SortOrder -> m [TxHashObject]
+getMempoolTransactionsByAddress' addr pg s = go (\p -> getMempoolTransactionsByAddress_ p addr pg s)
+
+-- | Get a list of transactions currently in Blockfrost.io mempool
+-- where at least one of the transaction inputs or outputs belongs to the address.
+--
+-- Queries 100 entries. To query all entries use 'Blockfrost.Client.Core.allPages'
+-- with principled variant of this function (suffixed with @'@)
+-- that accepts 'Paged' argument.
+getMempoolTransactionsByAddress :: MonadBlockfrost m => Address -> m [TxHashObject]
+getMempoolTransactionsByAddress addr = go (\p -> getMempoolTransactionsByAddress_ p addr def def)


### PR DESCRIPTION
Mempool API functions adjusted to not require passing in `Project` [#85](https://github.com/blockfrost/blockfrost-haskell/pull/85)
* Previous `getMempoolTransactions prj def def` is now simply `getMempoolTransactions` and a principled variant `getMempoolTransactions'` is provided accepting page and sort order parameters (for example `allPages $ \p -> getMempoolTransactions' p def`).
* Similar for `getMempoolTransactionsByAddress`.
* `getMempoolTransaction` now simply doesn't require passing `Project`